### PR TITLE
Add new TextSelectEnum sample to public APDFL samples repository

### DIFF
--- a/CPlusPlus/Sample_Source/Text/TextSelectEnum/TextSelectEnum.cpp
+++ b/CPlusPlus/Sample_Source/Text/TextSelectEnum/TextSelectEnum.cpp
@@ -1,0 +1,188 @@
+//
+// Copyright (c) 2018, Datalogics, Inc. All rights reserved.
+//
+// For complete copyright information, refer to:
+// http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+//
+// The TextSelectEnum sample demonstrates how the Library is able to select all of the 
+// text present in an area of the page. 
+//
+// Command-line:  <output-file>     (Optional)
+//
+// For more detail see the description of the UnicodeText sample program on our Developer’s site, 
+// http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/c1samples#TextSelectEnum
+
+#include "APDFLDoc.h"
+#include "InitializeLibrary.h"
+#include "DLExtrasCalls.h"
+#include "ASExtraCalls.h"
+#include "PagePDECntCalls.h"
+#include "PEWCalls.h"
+#include "PERCalls.h"
+#include <vector>
+
+#define DIR_LOC "../../../../Resources/Sample_Input/"
+#define DEF_INPUT "TextSearch.pdf"
+#define DEF_OUTPUT "TextSelectEnum-out.pdf"
+
+// A structure to hold the information returned by text select enum
+typedef struct enumeratedRun
+{
+    PDFont          font;
+    ASFixed         size;
+    PDColorValueRec color;
+    ASText          text;
+} EnumeratedRun;
+
+// A typedef to hold a list of words.
+typedef std::vector<EnumeratedRun> wordList;
+
+// This is the callback routine used to add one text run to the list of text runs
+ASBool enumSelectedTextUCS (void *procObj, PDFont font, ASFixed size, PDColorValue color, char *text, ASInt32 textLen)
+{
+    wordList *words = (wordList *)procObj;
+
+    EnumeratedRun thisWord;
+    thisWord.text = ASTextFromSizedUnicode ((ASUTF16Val *)text, kUTF16BigEndian, textLen);
+    thisWord.font = font;
+    thisWord.size = size;
+    memcpy ((char *)&thisWord.color, (char *)color, sizeof (PDColorValueRec));
+
+    words->push_back (thisWord);
+    return (true);
+}
+
+
+int main(int argc, char** argv)
+{
+    APDFLib libInit;
+    ASErrorCode errCode = 0;
+    if (libInit.isValid() == false)
+    {
+        errCode = libInit.getInitError();
+        std::cout << "Initialization failed with code " << errCode << std::endl;
+        return libInit.getInitError();
+    }
+    
+    std::string csInputFileName (argc > 1 ? argv[1] : DIR_LOC DEF_INPUT);
+    std::string csOutputFileName (argc > 2 ? argv[2] : DEF_OUTPUT);
+    std::cout << "Will search " << csInputFileName.c_str () << " for all text runs, "
+        << "and create a new document with one run, in the font, size, and color of the original, on"
+        << " each line of the document, and save to " << csOutputFileName.c_str () << std::endl;
+
+DURING
+
+    // Open the document 
+    APDFLDoc document (csInputFileName.c_str (), true);
+
+    // Step 1) Declare the selected text. 
+    //         In this sample, we will ask for all of the text on page 1.
+    PDPage page = PDDocAcquirePage (document.getPDDoc (), 0);
+    ASFixedRect pageSize;
+    PDPageGetCropBox (page, &pageSize);
+    PDTextSelect selection = PDDocCreateTextSelect (document.getPDDoc (), 0, &pageSize);
+
+    // Step 2) Acquire a list of all selected word in UCS format
+    wordList words;
+    PDTextSelectEnumTextUCS (selection, enumSelectedTextUCS, &words);
+
+    //Step 3) Release the source resources
+    //  (NOTE: Do NOT close the source document. We need to continue to 
+    //   exist to give meaning to the PDFonts, referenced in the runs.
+    PDPageRelease (page);
+
+
+    // Step 4) Create an output document, and write each run to one line of that document.
+    PDDoc outDoc = PDDocCreate ();
+    ASFixedRect newPageSize = { 0, FloatToASFixed (11.0 * 72), FloatToASFixed (8.5 * 72.0), 0 };
+    ASFixed indents = FloatToASFixed (72.0);
+    page = PDDocCreatePage (outDoc, PDDocGetNumPages (outDoc)-1, newPageSize);
+    PDEContent content = PDPageAcquirePDEContent (page, 0);
+    ASFixed Baseline = newPageSize.top - indents;
+
+    for (int i = 0; i < words.size (); i++)
+    {
+        EnumeratedRun run = words[i];
+
+        Baseline -= run.size;
+
+        if (Baseline < indents)
+        {
+            // If we go off the bottom of the page, 
+            //   finish the current page, and start a new page
+            PDPageSetPDEContent (page, 0);
+            PDPageReleasePDEContent (page, 0);
+            PDPageRelease (page);
+
+            Baseline = newPageSize.top - indents - run.size;
+            page = PDDocCreatePage (outDoc, PDDocGetNumPages (outDoc)-1, newPageSize);
+            content = PDPageAcquirePDEContent (page, 0);
+        }
+
+        ASFixedMatrix matrix = { run.size, 0, 0, run.size, indents, Baseline };
+
+        PDEText text = PDETextCreate ();
+        CosObj cosFont = PDFontGetCosObj (run.font);
+        PDEFont pdeFont = PDEFontCreateFromCosObj (&cosFont);
+
+        // Create the graphic state to display the text
+        PDEGraphicState gState;
+        PDEDefaultGState (&gState, sizeof (PDEGraphicState));
+        PDERelease ((PDEObject)gState.fillColorSpec.space);
+        switch (run.color.space)
+        {
+            case PDDeviceGray:
+                gState.fillColorSpec.space = PDEColorSpaceCreateFromName (ASAtomFromString ("DeviceGray"));
+                gState.fillColorSpec.value.color[0] = run.color.value[0];
+                break;
+            case PDDeviceRGB:
+                gState.fillColorSpec.space = PDEColorSpaceCreateFromName (ASAtomFromString ("DeviceRGB"));
+                gState.fillColorSpec.value.color[0] = run.color.value[0];
+                gState.fillColorSpec.value.color[1] = run.color.value[1];
+                gState.fillColorSpec.value.color[2] = run.color.value[2];
+                break;
+            case PDDeviceCMYK:
+                gState.fillColorSpec.space = PDEColorSpaceCreateFromName (ASAtomFromString ("DeviceCMYK"));
+                gState.fillColorSpec.value.color[0] = run.color.value[0];
+                gState.fillColorSpec.value.color[1] = run.color.value[1];
+                gState.fillColorSpec.value.color[2] = run.color.value[2];
+                gState.fillColorSpec.value.color[3] = run.color.value[3];
+                break;
+        }
+
+        // Set up the text state
+        // (We do not set the type size in the text state object, because we set it in the 
+        //  matrix object).
+        PDETextState tState;
+        memset ((char *)&tState, 0, sizeof (PDETextState));
+
+        PDETextAddASText (text, kPDETextRun, kPDEAfterLast, run.text,
+                            pdeFont, &gState, sizeof (PDEGraphicState),
+                            &tState, sizeof (PDETextState), &matrix);
+
+        PDEContentAddElem (content, PDEContentGetNumElems(content), (PDEElement)text);
+
+        PDERelease ((PDEObject)text);
+        PDERelease ((PDEObject)pdeFont);
+        PDERelease ((PDEObject)gState.fillColorSpec.space);
+        PDERelease ((PDEObject)gState.strokeColorSpec.space);
+    }
+
+    // Finish the last page
+    PDPageSetPDEContent (page, 0);
+    PDPageReleasePDEContent (page, 0);
+    PDPageRelease (page);
+
+    // Save the document 
+    ASPathName outPath = APDFLDoc::makePath (csOutputFileName.c_str ());
+    PDDocSave (outDoc, PDSaveFull, outPath, NULL, NULL, NULL);
+    ASFileSysReleasePath (NULL, outPath);
+    PDDocRelease (outDoc);
+
+HANDLER
+    errCode = ERRORCODE;
+    libInit.displayError(errCode);
+END_HANDLER
+
+    return errCode;              
+}

--- a/CPlusPlus/Sample_Source/Text/TextSelectEnum/TextSelectEnum.vcxproj
+++ b/CPlusPlus/Sample_Source/Text/TextSelectEnum/TextSelectEnum.vcxproj
@@ -1,0 +1,172 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{26B0DAAC-1B6E-4020-BEC0-D47DDBA263C6}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>BlankSample</RootNamespace>
+    <ProjectName>TextSelectEnum</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CONSOLE;_DEBUG;DEBUG;_WIN32;WIN32;WIN_ENV;WIN_PLATFORM;PRODUCT="HFTLibrary.h";PI_ACROCOLOR_VERSION=AcroColorHFT_VERSION_6;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\..\Include\Headers;..\..\_Common;..\..\_Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeaderFile />
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\..\..\Binaries</AdditionalLibraryDirectories>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;DL150PDFL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>DL150pdfl.dll</DelayLoadDLLs>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CONSOLE;_DEBUG;DEBUG;_WIN64;WIN64;WIN_ENV;WIN_PLATFORM;PRODUCT="HFTLibrary.h";PI_ACROCOLOR_VERSION=AcroColorHFT_VERSION_6;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\..\Include\Headers;..\..\_Common;..\..\_Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeaderFile />
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\..\..\Binaries</AdditionalLibraryDirectories>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;DL150PDFL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>DL150pdfl.dll</DelayLoadDLLs>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CONSOLE;WIN32;WIN32;WIN_ENV;WIN_PLATFORM;PRODUCT="HFTLibrary.h";PI_ACROCOLOR_VERSION=AcroColorHFT_VERSION_6;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\..\Include\Headers;..\..\_Common;..\..\_Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeaderFile />
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\..\..\Binaries</AdditionalLibraryDirectories>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;DL150PDFL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>DL150pdfl.dll</DelayLoadDLLs>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CONSOLE;WIN64;WIN64;WIN_ENV;WIN_PLATFORM;PRODUCT="HFTLibrary.h";PI_ACROCOLOR_VERSION=AcroColorHFT_VERSION_6;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\..\Include\Headers;..\..\_Common;..\..\_Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeaderFile />
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\..\..\Binaries</AdditionalLibraryDirectories>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;DL150PDFL.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>DL150pdfl.dll</DelayLoadDLLs>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="TextSelectEnum.cpp" />
+    <ClCompile Include="..\..\_Common\APDFLDoc.cpp" />
+    <ClCompile Include="..\..\_Common\InitializeLibrary.cpp" />
+    <ClCompile Include="..\..\..\Include\Source\PDFLInitCommon.c" />
+    <ClCompile Include="..\..\..\Include\Source\PDFLInitHFT.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\_Common\APDFLDoc.h" />
+    <ClInclude Include="..\..\_Common\InitializeLibrary.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/CPlusPlus/Sample_Source/Text/TextSelectEnum/TextSelectEnum.vcxproj.user
+++ b/CPlusPlus/Sample_Source/Text/TextSelectEnum/TextSelectEnum.vcxproj.user
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerEnvironment>PATH=../../../Binaries;%PATH%</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerEnvironment>PATH=../../../Binaries;%PATH%</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerEnvironment>PATH=../../../Binaries;%PATH%</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LocalDebuggerEnvironment>PATH=../../../Binaries;%PATH%</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>

--- a/CPlusPlus/Sample_Source/Text/TextSelectEnum/TextSelectEnum_32Bit.sln
+++ b/CPlusPlus/Sample_Source/Text/TextSelectEnum/TextSelectEnum_32Bit.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.21005.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TextSelectEnum", "TextSelectEnum.vcxproj", "{6CA37959-A591-4442-8819-AB9F8A8DA43D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6CA37959-A591-4442-8819-AB9F8A8DA43D}.Debug|Win32.ActiveCfg = Debug|Win32
+		{6CA37959-A591-4442-8819-AB9F8A8DA43D}.Debug|Win32.Build.0 = Debug|Win32
+		{6CA37959-A591-4442-8819-AB9F8A8DA43D}.Release|Win32.ActiveCfg = Release|Win32
+		{6CA37959-A591-4442-8819-AB9F8A8DA43D}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This sample demonstrates how to use the PDTextSelect feature in the Adobe PDF Library to
select text from within a defined area of a page in a PDF document and copy that text to
an output file.