### PR TITLE
Update TextSelectEnum.cpp and RenderPage.cpp sample programs

### DIFF
--- a/CPlusPlus/Sample_Source/Images/RenderPage/RenderPage.cpp
+++ b/CPlusPlus/Sample_Source/Images/RenderPage/RenderPage.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2007-2017, Datalogics, Inc. All rights reserved.
+// Copyright (c) 2007-2018, Datalogics, Inc. All rights reserved.
 //
 // For complete copyright information, refer to:
 // http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
@@ -10,14 +10,72 @@
 // http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/c1samples#renderpage
 
 #include "RenderPage.h"
+#include <math.h>
 
 //Statics
 ASAtom RenderPage::sDeviceRGB_K;
 ASAtom RenderPage::sDeviceCMYK_K;
 ASAtom RenderPage::sDeviceGray_K;
 
-// Constructor
-RenderPage::RenderPage(PDPage &pdPage, const char *colorSpace, const char *filterName, ASInt32 inBPC, float inResolution)
+// These are utility routines to convert Rects and Matrices between ASDouble and
+// ASReal, and ASFixed.
+// ASFixed was the original method of specifing "real" numbers in APDFL. It is still widely present in APDFL interfaces, though it is 
+//   limited by both it's resolution (0.0001 typically) and it range (+- 32767). There is a full complement of methods for combining
+//   matrices, and transforming and comparing rectangles. Internal to APDFL, ASFixed is now seldom used.
+// ASReal was introduced into APDFL later. It is implemented as a float, and it does not have the full 
+//   complement of transform methods. It is used here because it is needed in the interface to PDPageDrawContentsToMemoryWithParams.
+// ASDouble was introduced most recently. It has a full complement of transformation methods. Many interfaces to APDFL have been updated
+//   (Generally by the addition of "Ex" to the interface name) to provide/accept such values.
+//
+//  However, conversion between these forms is not always supplied. These routines provided the conversions needed for this sample.
+void ASDoubleRectToASReal (ASRealRect &out, ASDoubleRect &in)
+{
+    out.left = (ASReal)in.left;
+    out.right = (ASReal)in.right;
+    out.top = (ASReal)in.top;
+    out.bottom = (ASReal)in.bottom;
+}
+
+void ASDoubleMatrixToASReal (ASRealMatrix &out, ASDoubleMatrix &in)
+{
+    out.a = (ASReal)in.a;
+    out.b = (ASReal)in.b;
+    out.c = (ASReal)in.c;
+    out.d = (ASReal)in.d;
+    out.tx = (ASReal)in.h;
+    out.ty = (ASReal)in.v;
+}
+
+void ASFixedRectToASDouble (ASDoubleRect &out, ASFixedRect &in)
+{
+    out.left = ASFixedToFloat (in.left);
+    out.right = ASFixedToFloat (in.right);
+    out.top = ASFixedToFloat (in.top);
+    out.bottom = ASFixedToFloat (in.bottom);
+}
+
+void ASFixedMatrixToASDouble (ASDoubleMatrix &out, ASFixedMatrix &in)
+{
+    out.a = ASFixedToFloat (in.a);
+    out.b = ASFixedToFloat (in.b);
+    out.c = ASFixedToFloat (in.c);
+    out.d = ASFixedToFloat (in.d);
+    out.h = ASFixedToFloat (in.h);
+    out.v = ASFixedToFloat (in.v);
+}
+
+void ASDoubleToFixedRect (ASFixedRect &out, ASDoubleRect &in)
+{
+    out.left = FloatToASFixed (in.left);
+    out.right = FloatToASFixed (in.right);
+    out.top = FloatToASFixed (in.top);
+    out.bottom = FloatToASFixed (in.bottom);
+}
+
+// This both constructs the RenderPage object, and creates the page rendering. 
+//  The rendered page can be accessed as a bitmap via the methods GetImageBuffer() and GetImageBufferSize(), or as a PDEImage, 
+//  via the method GetPDEImage(). The PDEImage creation will be deferred until it is requested.
+RenderPage::RenderPage(PDPage &pdPage, const char *colorSpace, const char *filterName, ASInt32 inBPC, double inResolution)
 {
     // Set up the static colorspace atoms
     sDeviceRGB_K = ASAtomFromString("DeviceRGB");
@@ -25,78 +83,211 @@ RenderPage::RenderPage(PDPage &pdPage, const char *colorSpace, const char *filte
     sDeviceGray_K = ASAtomFromString("DeviceGray");
 
     //If you are using a decode filter such as FlateDecode, the filterArray values will be set here
-    filterArray = SetFilter(filterName);
-
-    //Set resolution.  The default resolution is 72 units per inch.  Thus a value of 72.0 is the same
-    //  To double the resolution, for example, you would set the value to 144.0.
-    resolution = SetResolution(inResolution);
+    memset (&filterArray, 0, sizeof (PDEFilterArray));
+    if (filterName)
+    {
+        filterArray.numFilters = 1;
+        filterArray.spec[0].name = ASAtomFromString (filterName);
+    }
+    
+    //Set resolution.
+    //  A PDF "unit" is, by default, 1/72nd of an inch. So a resolution of 72 is one PDF "unit" per pixel. 
+    //  if no resolution is set, we will use 72 DPI as our image reslution. This sample does not attempt to
+    //  support different horiziontal and vertical resolutions. APDFL, can easily support them by using a 
+    //  different scale factor in the scale matrix "a" (horiziontal) and "d" (vertical) members. The scale 
+    //  factors are simply (72.0 / resolution).
+    ASDouble resolution = 72.0;
+    if (inResolution > 0.0)
+        resolution = inResolution;
 
     //Get the colorspace atom, set the number of components per colorspace
-    //and store the appropriate colorspace for an output PDEImage
+    //  and store the appropriate colorspace for an output PDEImage
+    //  This sample will raise an exception if the color space is not one of
+    //  DeviceGray, DeviceRGB, or DeviceCMYK. APDFL supports a number of additional
+    //  color spaces. The image created may also be conformed to a given ICC Profile.
     csAtom = SetColorSpace(colorSpace);
 
-    //The stream of data being rasterized to memory is divided into units of n bits each, 
-    //  where n is the number of bits per component.  
+    //The size of each color component to be represented in the image.
     bpc = SetBPC(inBPC);
 
-    //Gets the matrix that transforms user space coordinates to rotated and cropped coordinates.
-    //  The origin of this space is the top-left of the rotated, cropped page. Y is decreasing
-    PDPageGetFlippedMatrix(pdPage, &matrix);
+    // Set up attributes for the PDEImage to be made by GetPDEImage
+    //   Height and Width in pixels will be added as they are known.
+    memset (&attrs, 0, sizeof (PDEImageAttrs));
+    attrs.flags = kPDEImageExternal;
+    attrs.bitsPerComponent = bpc;
 
-    //Gets the crop box for a page. The crop box is the region of the page to display and print
-    PDPageGetCropBox(pdPage, &pageRect);
+    //Get the matrix that transforms user space coordinates to rotated and cropped coordinates.
+    //  In PDF, the normal origin of an image is the lower left corner of the image, with 
+    //  position increasing in number up and to the right. This would be obtained using 
+    //  PDPageGetDefaultMatrix. However, most image formats prefer an origin of the top left 
+    //  corner. Drawing the image left to right, top to bottom. The interface PDPageGetFlippedMatrix
+    //  will obtain a matrix to draw the page in this order.
+    // NOTE: Both of these matrix accessors presume that the image begin drawn is the "cropped" image
+    //  of the page, and they will have the transform elements set to place the lower left hand corner
+    //  of the cropped page in the lower left hand corner of the image. This assumption is not always
+    //  how an application may wish to render a page. If your application wishes to render a different
+    //  area of the page, then you may want to modify, or generate, both the matrix and the page size
+    //  below to achive a different effect.
+    ASFixedMatrix cropFixedMatrix;
+    ASDoubleMatrix cropMatrix;
+    PDPageGetFlippedMatrix (pdPage, &cropFixedMatrix);
+    ASFixedMatrixToASDouble (cropMatrix, cropFixedMatrix);
 
-    //Set page coordinates/rectangle to crop box for PDDocCreatePage
-    destRect = SetPageRect(pageRect);
 
-    //Set the scale matrix that will be concatenated to the user space matrix
-    scaleMatrix = SetScaleMatrix(resolution);
+    //Gets the Cropped Page Size/Location for a given page. 
+    //  The Crop Box reflects the visible contents of the page. It may often be displaced from the 
+    // media origin of the page. In this sample, the displacement of the cropped area of the page is
+    // included automatically in the matrix obtained above
+    ASFixedRect cropFixedRect;
+    PDPageGetCropBox (pdPage, &cropFixedRect);
+
+    // The user may ask for the size of the image in PDF units.
+    // "Normalize" the crop box to a zero/zero origin to obtain it's
+    // size in PDF units.
+    imageSize.left = imageSize.bottom = 0;
+    imageSize.right = cropFixedRect.right - cropFixedRect.left;
+    imageSize.top = cropFixedRect.top - cropFixedRect.bottom;
+
+    // We want to display the page upright, regardless of how it was imaged. 
+    // The matrix returned by PDPageGetFlippedMatrix() will include the rotation
+    // applied to the page (as will PDPageGetDefaultMatrix()). However, the rectangle
+    // returned by PDPageGetMediaBox will not be rotated. So if the page is rotated
+    // 90 or 270 degrees, we need to swap those sides here.
+    PDRotate rotation = PDPageGetRotate (pdPage);
+    if ((rotation == 90) || (rotation == 270))
+    {
+        ASFixed save = imageSize.top;
+        imageSize.top = imageSize.right;
+        imageSize.right = save;
+    }
+
+    // Convert to ASDouble values for computations
+    ASDoubleRect cropRect;
+    ASFixedRectToASDouble (cropRect, imageSize);
+
+    // The destination rectangle is in Pixels, while all other measurements
+    // till now are in PDF Units (1/72 of an inch). If we set the PDEImageAttrs
+    // width and depth here, we can use the results to form a Destination Rectangle
+    // NOTE: This is where we apply the resolution to convert from Points to Pixels.
+    //  We round up to include space for partial pixels at the edges.
+    attrs.width = (ASInt32)floor (((cropRect.right * resolution) / 72.0) + 0.5);
+    attrs.height = (ASInt32)floor (((cropRect.top * resolution) / 72.0) + 0.5);
+
+    // Set up the destinantion rectangle. 
+    // This is a description of the image in pixels, so it will always
+    // have it's origin at 0,0.
+    ASRealRect destRect;
+    destRect.left = destRect.bottom = 0;
+    destRect.right = (ASReal)attrs.width;
+    destRect.top = (ASReal)attrs.height;
+
+    //Create the scale matrix that will be concatenated to the user space matrix
+    ASDoubleMatrix scaleMatrix;
+    scaleMatrix.a = scaleMatrix.d = resolution / 72.0;
+    scaleMatrix.b = scaleMatrix.c = scaleMatrix.h = scaleMatrix.v = 0;
 
     //Apply the scale to the default matrix
-    ASFixedMatrixConcat(&matrix, &scaleMatrix, &matrix);
-    ASFixedMatrixTransformRect(&scaledDestRect, &scaleMatrix, &destRect);
+    ASDoubleMatrixConcat(&cropMatrix, &scaleMatrix, &cropMatrix);
 
-    //Allocate the buffer fo storing the rendered page content,
-    //  and initialize to background of white as appropriate for the colorspace selected
-    bufferSize = SetBufferSize(pdPage, matrix, csAtom, bpc, scaledDestRect);
-    buffer =   new char[bufferSize];
-    char bkgColor = csAtom == sDeviceCMYK_K ? 0x0 : 0xff;
-    memset(buffer, bkgColor, bufferSize);
 
-    // Leave the memory buffer uninitialized for non-Device color spaces.
+    // "Best Practice" is to use PDPageDrawContentsToMemoryWithParams, as it allows
+    // the matrix and rects to be specified in floating point, eliminating the need
+    // to test for ASFixed Overflows.
+    PDPageDrawMParamsRec drawParams;
+
+    // Many of the values in the params record will not be used for this simple rendering. 
+    // so we set them all to zeros initally
+    memset (&drawParams, 0, sizeof (PDPageDrawMParamsRec));
+    drawParams.size = sizeof (PDPageDrawMParamsRec);
+    drawParams.csAtom = csAtom;
+    drawParams.bpc = bpc;
+
+    // For this example we will smooth (anti-alias) all of the marks. For a given application,
+    // this may or may not be desireable. See the enumeration PDPageDrawSmoothFlags for the full set of options.
+    drawParams.smoothFlags = kPDPageDrawSmoothText | kPDPageDrawSmoothLineArt | kPDPageDrawSmoothImage;
+
+    // The DoLazyErase flag is usually, if not always turned on, UseAnnotFaces will cause annotations
+    // in the page to be displayed, and kPDPageDsiplayOverprintPreview will display the page showing 
+    // overprinting. The precise meaning of these flags, as well as others that may be used here, can be
+    // seen in the defintion of PDPageDrawFlags
+    drawParams.flags = kPDPageDoLazyErase | kPDPageUseAnnotFaces | kPDPageDisplayOverPrintPreview;
+
+    // This is a bit clumsy, because features were added over time. The matrices and rectangles in this
+    // interface use ASReal as thier base, rather than ASDouble. But there is not a complete set of 
+    // concatenation and transformation methods for ASReal. So we generally generate the matrix and 
+    // rectangle values using ASDouble, and convert to ASReal. 
+    ASDoubleRect doubleUpdateRect;
+    ASRealRect realUpdateRect;
+    ASRealMatrix realCropMatrix;
+    ASFixedRectToASDouble (doubleUpdateRect, cropFixedRect);    // This rectangle, the portion of the page to display,
+    ASDoubleRectToASReal (realUpdateRect, doubleUpdateRect);    //   must NOT be swapped to reflect page rotation.
+    ASDoubleMatrixToASReal (realCropMatrix, cropMatrix);
+    drawParams.asRealDestRect = &destRect;                   // This is where the image is drawn on the resultant bitmap.
+                                                             //   It is generally set at 0, 0 and width/height in pixels.
+    drawParams.asRealUpdateRect = &realUpdateRect;           // This is the portion of the document to be drawn. If omitted, 
+                                                             // it will be the document media box, which is generally what is wanted.
+    drawParams.asRealMatrix = &realCropMatrix;               // This is the scale factor of the page from points to pixels, and the
+                                                             // displacement of the lower left hand corner of the area of the page
+                                                             // to be rendered.
+
+    // Additional values in this record control such features as drawing separations, 
+    // specifiying a desired output profile, selecting optional content, and providing for 
+    // a progress reporting callback.
+
+    //Allocate the buffer for storing the rendered page content
+    // It is important that ALL of the flags and options used in the actual draw be set the same here!
+    // Calling this interface with drawParms.bufferSize or drawParams.buffer equal to zero will return the size of the buffer
+    //   needed to contain this image. This is the most certain way to get the correct buffer size. If we call this routine with a buffer
+    //   that is not large enough to contain the image, we will not draw the image, but will simply, silently, return the size of the buffer
+    //   needed!
+    bufferSize = PDPageDrawContentsToMemoryWithParams (pdPage, &drawParams);   // This call, with a NULL buffer pointer, returns needed buffer size
+    
+    //  One frequent failure point in rendering images is being unable to allocate sufficient contigious space 
+    //  for the bitmap buffer. Here, that will be indicated by a zero value for drawParams.buffer after the 
+    //  call to malloc. If the buffer size is larger than the internal limit of malloc, it may also raise an
+    //  interupt! Catch these conditions here, and raise an out of memory error to the caller.
+    try
+    {
+        buffer = (char *)ASmalloc (bufferSize);
+        if (!buffer)
+            ASRaise (genErrNoMemory);
+    }
+    catch (...)
+    {
+        ASRaise (genErrNoMemory);
+    }
+
+    // With these values in place, the next call to PDPageDrawContentsToMemoryWithParams() will fill the bitmap.
+    drawParams.bufferSize = bufferSize;
+    drawParams.buffer = buffer;
 
     // Render page content to the bitmap buffer
-    PDPageDrawContentsToMemory ( pdPage,
-                                 kPDPageDoLazyErase | kPDPageUseAnnotFaces,
-                                 &matrix, 
-                                 NULL,
-                                 kPDPageDrawSmoothText | kPDPageDrawSmoothLineArt | kPDPageDrawSmoothImage,
-                                 csAtom, 
-                                 bpc, 
-                                 &scaledDestRect, 
-                                 buffer, 
-                                 bufferSize,
-                                 NULL, NULL);
+    PDPageDrawContentsToMemoryWithParams (pdPage, &drawParams);
 
-    // Set up attributes for the PDEImage made by MakePDEImage - these attributes are also
-    // used to repad the output buffer (from 32-bit row alignment to 8-bit alignment) in
-    // the PadCompute function below
-    SetImageAttrs(scaledDestRect, bpc);
 
-    //If the number of data bits per row is not a multiple of 8, the end of the row is padded with 
-    //  extra bits to fill out the last byte. A PDF consumer application ignores these padding bits.
-    attrs.width = PadCompute(attrs, bpc, nComps, buffer, bufferSize);
+    // The bitmap data generated by PDPageDrawContentsToWindow uses 32-bit aligned rows. 
+    // The PDF image operator expects, however, 8-bit aligned image rows. 
+    // To remedy this difference, we check to see if the 32-bit aligned width
+    // is different from the 8-bit aligned width. If so, we fix the image data by 
+    // stripping off the padding at the end of each row.
+    ASInt32 createdWidth = ((((attrs.width * bpc * nComps) + 31) / 32) * 4);
+    ASInt32 desiredWidth = ((attrs.width * bpc * nComps) / 8);
+
+    if (createdWidth != desiredWidth)
+    {
+        for (int row = 1; row < attrs.height; row++)
+            memmove (&buffer[row * desiredWidth], &buffer[row * createdWidth], desiredWidth);
+        drawParams.bufferSize = desiredWidth * attrs.height;
+    }
+
 }
 
 RenderPage::~RenderPage() 
 { 
     if(buffer)
-    {
-        delete[] buffer;
-    }
-    buffer = 0;
+        ASfree (buffer);
+    buffer = NULL;
 
-    PDERelease(reinterpret_cast<PDEObject>(image));
     PDERelease(reinterpret_cast<PDEObject>(cs));
 }
 
@@ -110,81 +301,64 @@ ASInt32 RenderPage::GetImageBufferSize()
     return bufferSize;
 }
 
-ASFixedRect RenderPage::GetImageRect()
+ASFixedRect RenderPage::GetImageSize()
 {
-    return pageRect;
+    return imageSize;
 }
 
-PDEImage RenderPage::MakePDEImage()
+PDEImage RenderPage::GetPDEImage(PDDoc outDoc)
 {
-    //Prepare the image attributes
-    attrs = SetImageAttrs(scaledDestRect, bpc);
+    // When we are encoding in DCT, we need to know the height and
+    // width of the image in pixels, and the document we will be 
+    // writing the PDE Image into. This is not known before now,
+    // so we will do it just before creating the image.
+    if (filterArray.spec[0].name == ASAtomFromString("DCTDecode"))
+        SetDCTFilterParams(PDDocGetCosDoc(outDoc));
 
     //Create the image matrix using the height/width attributes and apply the resolution.
-    imageMatrix = SetImageMatrix(attrs, resolution);
+    ASDoubleMatrix imageMatrix;
+    imageMatrix.a = ASFixedToFloat (imageSize.right);
+    imageMatrix.d = ASFixedToFloat (imageSize.top);
+    imageMatrix.b = imageMatrix.c = imageMatrix.h = imageMatrix.v = 0;
 
     // Create an image XObject from the bitmap buffer to embed in the output document
-    image = PDEImageCreate ( &attrs, 
-                             sizeof(attrs),
-                             &imageMatrix, 
-                             0,
-                             cs, 
-                             NULL,
-                             &filterArray, 
-                             0,
-                             (unsigned char*) buffer, 
-                             bufferSize);
+    PDEImage image = PDEImageCreateInCosDocEx ( &attrs, 
+                                                sizeof(attrs),
+                                                &imageMatrix, 
+                                                0,
+                                                cs, 
+                                                NULL,
+                                                &filterArray, 
+                                                0,
+                                                (unsigned char*) buffer, 
+                                                bufferSize,
+                                                PDDocGetCosDoc (outDoc));
 
     return image;
 }
 
-PDEImageAttrs RenderPage::SetImageAttrs(ASFixedRect scaledDestRect, ASInt32 bpc)
+
+PDEFilterArray RenderPage::SetDCTFilterParams(CosDoc cosDoc)
 {
-    memset(&attrs, 0, sizeof(PDEImageAttrs));
-    attrs.flags = kPDEImageExternal;
-    attrs.height = abs(ASFixedRoundToInt16(scaledDestRect.top) - ASFixedRoundToInt16(scaledDestRect.bottom));
-    attrs.width = abs(ASFixedRoundToInt16(scaledDestRect.right) - ASFixedRoundToInt16(scaledDestRect.left));
-    attrs.bitsPerComponent = bpc;
-    return attrs;
-}
+    // Create a new Cos dictionary
+    CosObj dictParams = CosNewDict(cosDoc, false, 4);
 
-PDEFilterArray RenderPage::SetFilter(const char *filterName)
-{    
-    memset(&filterArray, 0, sizeof(PDEFilterArray));
+    // Populate the dictionary with required entries to do JPEG compression
+    // (only Columns, Rows, and the number of color dimensions needed for sraight JPEG)
+    CosDictPut(dictParams, ASAtomFromString("Columns"),
+        CosNewInteger(cosDoc, false, attrs.width));
+    CosDictPut(dictParams, ASAtomFromString("Rows"),
+        CosNewInteger(cosDoc, false, attrs.height));
+    CosDictPut(dictParams, ASAtomFromString("Colors"),
+        CosNewInteger(cosDoc, false, nComps));
 
-    if(filterName)
-    {
-        filterArray.numFilters = 1;
-        filterArray.spec[0].name = ASAtomFromString(filterName);
-    }
+    filterArray.numFilters = 1;
+    filterArray.spec[0].encodeParms = dictParams;
+    filterArray.spec[0].decodeParms = CosNewNull();
+
     return filterArray;
 }
 
-//Apply the proportional resolution, width, and  height to the image matrix. 
-ASFixedMatrix RenderPage::SetImageMatrix(PDEImageAttrs attrs, float resolution)
-{    
-    imageMatrix.a = FloatToASFixed(attrs.width / (resolution / 72.0));
-    imageMatrix.d = FloatToASFixed(attrs.height / (resolution / 72.0));
-    imageMatrix.b = imageMatrix.c = 0;
-    imageMatrix.h = imageMatrix.v = 0;
-    return imageMatrix;
-}
-
-//Create a matrix to use to increase or decrease the default matrix via concatenation
-ASFixedMatrix RenderPage::SetScaleMatrix(float resolution)
-{   
-    scaleMatrix.a = scaleMatrix.d = FloatToASFixed(resolution / 72.0);
-    scaleMatrix.b = scaleMatrix.c = scaleMatrix.h = scaleMatrix.v = 0;
-    return scaleMatrix;
-}
-
-ASFixedRect RenderPage::SetPageRect(ASFixedRect destRect)
-{
-    pageRect.left = pageRect.bottom = 0;
-    pageRect.right = destRect.right - destRect.left;
-    pageRect.top = destRect.top - destRect.bottom;
-    return pageRect;
-}
 
 // Validate colorspace selection and set the channels per color
 ASAtom RenderPage::SetColorSpace(const char *colorSpace)
@@ -228,71 +402,11 @@ ASInt32 RenderPage::SetBPC(ASInt32 bitsPerComp)
     }
     if(csAtom==sDeviceGray_K)
     {
-        if(bitsPerComp == 1 || bitsPerComp == 8 || bitsPerComp == 24)
-        {}else
+        if((bitsPerComp != 1) && (bitsPerComp != 8) && (bitsPerComp != 24))
         {
             // Reset to 8
             bpc = 8;
         }
     }
     return bpc;
-}
-
-ASInt32 RenderPage::PadCompute(PDEImageAttrs attrs, ASInt32 bpc, ASInt32 nComps, char *buffer, ASInt32 bufferSize)
-{   
-    // The bitmap data generated by PDPageDrawContentsToWindow is 32-bit aligned. 
-    // The PDF image operator expects, however, 8-bit aligned image data. 
-    // To remedy this difference, we check to see if the 32-bit aligned width
-    // is different from the 8-bit aligned width. If so, we fix the image data by 
-    // stripping off the padding at the end
-    if (((((attrs.width * bpc * nComps) + 31) / 32) * 4) != ((attrs.width * bpc * nComps) /    8))
-    {
-        char *src, *dest;
-        int sw, dw;                    
-        sw = ((((attrs.width * bpc * nComps) + 31) / 32) * 4);
-        if (bpc == 1)
-            dw = attrs.width / 8 + ((attrs.width % 8) ? 1 : 0);
-        else
-            dw = (attrs.width * bpc * nComps) / 8;
-        src = dest = buffer;
-        // Copy the source bytes to the destination
-        for (int i = 0; i < attrs.height; i++) {
-            for (int j = 0; j < dw; j++) 
-                dest[j] = src[j];
-            src += sw; dest += dw;
-        }
-        // Recalculate buffer size
-        bufferSize = dw * attrs.height;
-    } else {
-        attrs.width = (((( attrs.width* bpc * nComps) + 31) / 32) * 4) * 8 / (bpc * nComps);
-    }
-    return attrs.width;
-}
-
-//Calculate buffer size needed to for page contents
-ASInt32 RenderPage::SetBufferSize(PDPage pdPage, ASFixedMatrix &matrix, ASAtom csAtom, ASInt32 bpc, ASFixedRect scaledDestRect)
-{   
-    bufferSize = PDPageDrawContentsToMemory ( pdPage,
-                                              kPDPageDoLazyErase,
-                                              &matrix, 
-                                              NULL,
-                                              0,
-                                              csAtom,
-                                              bpc,
-                                              &scaledDestRect,
-                                              NULL,
-                                              0, 
-                                              NULL, 
-                                              NULL);
-    return bufferSize;
-}
-
-//Correct for a resolution lower than or equal to zero
-float RenderPage::SetResolution(float inResolution)
-{   
-    if(inResolution<=0.0)
-        resolution=72.0;
-    else
-        resolution = inResolution;
-    return resolution; 
 }

--- a/CPlusPlus/Sample_Source/Images/RenderPage/RenderPage.h
+++ b/CPlusPlus/Sample_Source/Images/RenderPage/RenderPage.h
@@ -21,22 +21,16 @@
 #include "PagePDECntCalls.h"
 #include "PDFLExpT.h"
 #include "PDFLCalls.h"
+#include "DLExtrasCalls.h"
 
 
 class RenderPage 
 {
 private:
     PDPage              pdPage;
-    PDEImage            image; 
     PDEImageAttrs       attrs;
     PDEColorSpace       cs;
     PDEFilterArray      filterArray;
-    ASFixedMatrix       matrix;
-    ASFixedMatrix       scaleMatrix;
-    ASFixedMatrix       imageMatrix; 
-    ASFixedRect         destRect;
-    ASFixedRect         scaledDestRect;
-    ASFixedRect         pageRect;
     ASAtom              csAtom;
     ASInt32             nComps;
     ASInt32             bufferSize;
@@ -44,29 +38,23 @@ private:
     char*               buffer; 
     char*               colorSpace;
     char*               filterName;
-    float               resolution;
 
-    PDEImageAttrs       SetImageAttrs(ASFixedRect scaledDestRect, ASInt32 bpc);
-    PDEFilterArray      SetFilter(const char *filterName);
-    ASFixedMatrix       SetImageMatrix(PDEImageAttrs attrs, float resolution);
-    ASFixedMatrix       SetScaleMatrix(float resolution);
-    ASFixedRect         SetPageRect(ASFixedRect	destRect);
+    ASFixedRect         imageSize;      // This will carry the image size in PDF units.
+
+    PDEFilterArray      SetDCTFilterParams(CosDoc cosDoc);
     ASAtom              SetColorSpace(const char *colorSpace);
     ASInt32             SetBPC(ASInt32 bitsPerComp); 
-    ASInt32             PadCompute(PDEImageAttrs attrs, ASInt32 bpc, ASInt32 nComps, char *buffer, ASInt32 bufferSize);	 
-    ASInt32             SetBufferSize(PDPage pdPage, ASFixedMatrix &matrix, ASAtom csAtom, ASInt32 bpc, ASFixedRect scaledDestRect);
-    float               SetResolution(float resolution);
 
     static ASAtom       sDeviceRGB_K;
     static ASAtom       sDeviceCMYK_K;
     static ASAtom       sDeviceGray_K;
 
 public:
-    RenderPage(PDPage &pdPage, const char *colorSpace, const char *filterName, ASInt32 bpc, float resolution);
+    RenderPage(PDPage &pdPage, const char *colorSpace, const char *filterName, ASInt32 bpc, double resolution);
     ~RenderPage();
 
     char*               GetImageBuffer();
     ASInt32             GetImageBufferSize();
-    PDEImage            MakePDEImage();
-    ASFixedRect         GetImageRect();
+    PDEImage            GetPDEImage(PDDoc outDoc);
+    ASFixedRect         GetImageSize();
 };

--- a/CPlusPlus/Sample_Source/Images/RenderPage/mainproc.cpp
+++ b/CPlusPlus/Sample_Source/Images/RenderPage/mainproc.cpp
@@ -4,7 +4,7 @@
 // For complete copyright information, refer to:
 // http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
 //
-// Sample: RenderPage - Demonstrates the process of rasterizing a PDF page
+// Sample: RenderPage - Demonstrates the process of rasterizing the cropped area of a PDF page
 //   and placing the resulting raster as an image into a different PDF document.
 //
 //  Command-line:    <input-file>  <output-file-prefix>      (Both are optional)
@@ -23,16 +23,20 @@
 #define DEF_INPUT "RenderPage.pdf"
 #define DEF_OUTPUT "RenderPage-out.pdf"
 
-#define RESOLUTION  150.0         // Other common choices might be 72.0, 150.0, 200.0, 300.0, or 600.0  
+#define RESOLUTION  300.0         // Other common choices might be 72.0, 150.0, 200.0, 300.0, or 600.0
 #define COLORSPACE  "DeviceRGB"   // Typically this, DeviceGray or DeviceCMYK
-#define FILTER      "FlateDecode" // Could also be ASCIIHexDecode, LZWDecode, DCTDecode
+#define FILTER      "FlateDecode"	  //"FlateDecode" // Could also be ASCIIHexDecode, LZWDecode, DCTDecode
 #define BPC         8             // This must be 8 for DeviceRGB and DeviceCYMK, 
                                   //  1, 8, or 24 for DeviceGray
 
 int main(int argc, char** argv)
 {
-    APDFLib libInit;
     ASErrorCode errCode = 0;
+
+    // Initialize the library
+    APDFLib libInit;
+
+    // If library in initialization failed.
     if (libInit.isValid() == false)
     {
         errCode = libInit.getInitError();
@@ -40,6 +44,7 @@ int main(int argc, char** argv)
         return libInit.getInitError();
     }
     
+    // Report on action to be taken
     std::string csInputFileName ( argc > 1 ? argv[1] : DIR_LOC DEF_INPUT );
     std::string csOutputFileName ( argc > 2 ? argv[2] : DEF_OUTPUT );
     std::cout << "Rendering " << csInputFileName.c_str() << " to " << csOutputFileName.c_str()
@@ -48,28 +53,50 @@ int main(int argc, char** argv)
 
 DURING
 
-    // Open the input document and get the first page
+    // Open the input document and acquire the first page
     APDFLDoc inDoc ( csInputFileName.c_str(), true);
     PDPage pdPage = inDoc.getPage(0);
 
     // Construction of the drawPage object does all the work to rasterize the page
     RenderPage drawPage(pdPage, COLORSPACE, FILTER, BPC, RESOLUTION); 
 
+    // Release the first page.
+    PDPageRelease (pdPage);
+
+    // Create a document to hold the rendered page
     APDFLDoc outDoc;
-    PDPage outputPDPage = PDDocCreatePage(outDoc.getPDDoc(), PDBeforeFirstPage, drawPage.GetImageRect());
+
+    // Get the size of the image, in PDF Units
+    ASFixedRect imageSize = drawPage.GetImageSize ();
+
+    // Construct a page to contain the image, exactly the size of the image.
+    PDPage outputPDPage = PDDocCreatePage(outDoc.getPDDoc(), PDBeforeFirstPage, imageSize);
+
+    // Acquire the PDE Content of the newly created page
     PDEContent content = PDPageAcquirePDEContent(outputPDPage, 0);
 
     // The call to MakePDEImage synthesizes a PDEImage object from the rasterized PDF page
     // created in the constructor, suitable for placing onto a PDF page.
-    PDEContentAddElem(content, 0, (PDEElement) drawPage.MakePDEImage() );
+    PDEImage pageImage = drawPage.GetPDEImage (outDoc.getPDDoc ());
+
+    // Insert the PDEImage into the page, and release it after it is used.
+    PDEContentAddElem(content, 0, reinterpret_cast<PDEElement>(pageImage));
+
+    // Release the PDEImage after it is used in the page
+    PDERelease (reinterpret_cast<PDEObject>(pageImage));
+    
+    // Set the update PDE Content into the page
     PDPageSetPDEContentCanRaise(outputPDPage, 0);
+
+    // Release the pages PDEContent
     PDPageReleasePDEContent(outputPDPage, 0);
 
-    outDoc.saveDoc ( csOutputFileName.c_str(), PDSaveFull | PDSaveCollectGarbage);
+    // Release the newly create page
+    PDPageRelease (outputPDPage);
 
-    PDPageRelease(outputPDPage);
-    PDPageRelease(pdPage);
-    
+    // Save the outout Document
+    outDoc.saveDoc ( csOutputFileName.c_str(), PDSaveFull );
+
 HANDLER
     errCode = ERRORCODE;
     libInit.displayError(errCode);


### PR DESCRIPTION
RenderPage sample updated to properly rotate the image size when the page is rotated using PDRotate.

TextSelectEnum sample updated to use PDDocCreateTextUCS, and to use the font Arial Unicode MS for all type.