### PR TITLE
Update .NET Core samples search libgdiplus library

### DIFF
--- a/DotNETCore/Sample_Source/Images/DrawSeparations/DrawSeparations.cs
+++ b/DotNETCore/Sample_Source/Images/DrawSeparations/DrawSeparations.cs
@@ -24,16 +24,15 @@ namespace DrawSeparations
         static void Main(string[] args)
         {
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .OSX) &&
-                !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
+                .OSX) && !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on macOS.");
                 return;
             }
 
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .Linux) &&
-                !System.IO.File.Exists("/usr/lib64/libgdiplus.so"))
+                .Linux) && !System.IO.File.Exists("/usr/lib64/libgdiplus.so") &&
+                !System.IO.File.Exists("/usr/lib/libgdiplus.so"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on Linux.");
                 return;

--- a/DotNETCore/Sample_Source/Images/DrawToBitmap/DrawToBitmap.cs
+++ b/DotNETCore/Sample_Source/Images/DrawToBitmap/DrawToBitmap.cs
@@ -370,7 +370,8 @@ namespace DrawToBitmap
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-                !System.IO.File.Exists("/usr/lib64/libgdiplus.so"))
+                !System.IO.File.Exists("/usr/lib64/libgdiplus.so") &&
+                !System.IO.File.Exists("/usr/lib/libgdiplus.so"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on Linux.");
                 return;

--- a/DotNETCore/Sample_Source/Images/GetSeparatedImages/GetSeparatedImages.cs
+++ b/DotNETCore/Sample_Source/Images/GetSeparatedImages/GetSeparatedImages.cs
@@ -23,16 +23,15 @@ namespace GetSeparatedImages
         static void Main(string[] args)
         {
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .OSX) &&
-                !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
+                .OSX) && !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on macOS.");
                 return;
             }
 
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .Linux) &&
-                !System.IO.File.Exists("/usr/lib64/libgdiplus.so"))
+                .Linux) && !System.IO.File.Exists("/usr/lib64/libgdiplus.so") &&
+                !System.IO.File.Exists("/usr/lib/libgdiplus.so"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on Linux.");
                 return;

--- a/DotNETCore/Sample_Source/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.cs
+++ b/DotNETCore/Sample_Source/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.cs
@@ -88,16 +88,15 @@ namespace ImageEmbedICCProfile
         static void Main(string[] args)
         {
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .OSX) &&
-                !File.Exists("/usr/local/lib/libgdiplus.dylib"))
+                .OSX) && !File.Exists("/usr/local/lib/libgdiplus.dylib"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on macOS.");
                 return;
             }
 
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .Linux) &&
-                !File.Exists("/usr/lib64/libgdiplus.so"))
+                .Linux) && !System.IO.File.Exists("/usr/lib64/libgdiplus.so") &&
+                !System.IO.File.Exists("/usr/lib/libgdiplus.so"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on Linux.");
                 return;

--- a/DotNETCore/Sample_Source/Images/ImageExport/ImageExport.cs
+++ b/DotNETCore/Sample_Source/Images/ImageExport/ImageExport.cs
@@ -146,16 +146,15 @@ namespace ImageExport
         static void Main(String[] args)
         {
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .OSX) &&
-                !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
+                .OSX) && !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on macOS.");
                 return;
             }
 
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .Linux) &&
-                !System.IO.File.Exists("/usr/lib64/libgdiplus.so"))
+                .Linux) && !System.IO.File.Exists("/usr/lib64/libgdiplus.so") &&
+                !System.IO.File.Exists("/usr/lib/libgdiplus.so"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on Linux.");
                 return;

--- a/DotNETCore/Sample_Source/Images/ImageExtraction/ImageExtraction.cs
+++ b/DotNETCore/Sample_Source/Images/ImageExtraction/ImageExtraction.cs
@@ -66,16 +66,15 @@ namespace ImageExtraction
         static void Main(string[] args)
         {
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .OSX) &&
-                !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
+                .OSX) && !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on macOS.");
                 return;
             }
 
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .Linux) &&
-                !System.IO.File.Exists("/usr/lib64/libgdiplus.so"))
+                .Linux) && !System.IO.File.Exists("/usr/lib64/libgdiplus.so") &&
+                !System.IO.File.Exists("/usr/lib/libgdiplus.so"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on Linux.");
                 return;

--- a/DotNETCore/Sample_Source/Images/ImageFromStream/ImageFromStream.cs
+++ b/DotNETCore/Sample_Source/Images/ImageFromStream/ImageFromStream.cs
@@ -28,16 +28,15 @@ namespace ImageFromStream
         static void Main(string[] args)
         {
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .OSX) &&
-                !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
+                .OSX) &&!System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on macOS.");
                 return;
             }
 
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .Linux) &&
-                !System.IO.File.Exists("/usr/lib64/libgdiplus.so"))
+                .Linux) && !System.IO.File.Exists("/usr/lib64/libgdiplus.so") &&
+                !System.IO.File.Exists("/usr/lib/libgdiplus.so"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on Linux.");
                 return;

--- a/DotNETCore/Sample_Source/Images/RasterizePage/RasterizePage.cs
+++ b/DotNETCore/Sample_Source/Images/RasterizePage/RasterizePage.cs
@@ -35,16 +35,15 @@ namespace RasterizePage
         static void Main(string[] args)
         {
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .OSX) &&
-                !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
+                .OSX) && !System.IO.File.Exists("/usr/local/lib/libgdiplus.dylib"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on macOS.");
                 return;
             }
 
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform
-                    .Linux) &&
-                !System.IO.File.Exists("/usr/lib64/libgdiplus.so"))
+                .Linux) && !System.IO.File.Exists("/usr/lib64/libgdiplus.so") &&
+                !System.IO.File.Exists("/usr/lib/libgdiplus.so"))
             {
                 Console.WriteLine("Please install libgdiplus first to access the System.Drawing namespace on Linux.");
                 return;


### PR DESCRIPTION
These C# samples were updated to search for a secondary known location
for the libgdiplus shared library. This library is required to use .NET
Core with Linux.