### PR TITLE
Update RenderPage.cpp sample program

### DIFF
--- a/CPlusPlus/Sample_Source/Images/RenderPage/RenderPage.cpp
+++ b/CPlusPlus/Sample_Source/Images/RenderPage/RenderPage.cpp
@@ -301,8 +301,12 @@ PDEImage RenderPage::GetPDEImage(PDDoc outDoc) {
     // width of the image in pixels, and the document we will be
     // writing the PDE Image into. This is not known before now,
     // so we will do it just before creating the image.
-    if (filterArray.spec[0].name == ASAtomFromString("DCTDecode"))
+    if (filterArray.spec[0].name == ASAtomFromString("DCTDecode")) {
         SetDCTFilterParams(PDDocGetCosDoc(outDoc));
+    }
+    else if (filterArray.spec[0].name == ASAtomFromString("CCITTFaxDecode")) {
+        SetCCITTFaxFilterParams(PDDocGetCosDoc(outDoc));
+    }
 
     // Create the image matrix using the height/width attributes and apply the resolution.
     ASDoubleMatrix imageMatrix;
@@ -415,6 +419,19 @@ PDEFilterArray RenderPage::SetDCTFilterParams(CosDoc cosDoc) {
     filterArray.numFilters = 1;
     filterArray.spec[0].encodeParms = dictParams;
     filterArray.spec[0].decodeParms = CosNewNull();
+
+    return filterArray;
+}
+
+PDEFilterArray RenderPage::SetCCITTFaxFilterParams(CosDoc cosDoc) {
+    // Create a new Cos dictionary
+    CosObj dictParams = CosNewDict(cosDoc, false, 4);
+
+    CosDictPut(dictParams, ASAtomFromString("Columns"), CosNewInteger(cosDoc, false, attrs.width));
+    CosDictPut(dictParams, ASAtomFromString("Rows"), CosNewInteger(cosDoc, false, attrs.height));
+
+    filterArray.numFilters = 1;
+    filterArray.spec[0].encodeParms = filterArray.spec[0].decodeParms = dictParams;
 
     return filterArray;
 }

--- a/CPlusPlus/Sample_Source/Images/RenderPage/RenderPage.h
+++ b/CPlusPlus/Sample_Source/Images/RenderPage/RenderPage.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017, Datalogics, Inc. All rights reserved.
+// Copyright (c) 2017-2021, Datalogics, Inc. All rights reserved.
 //
 // For complete copyright information, refer to:
 // http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
@@ -40,10 +40,13 @@ class RenderPage {
     ASFixedRect imageSize; // This will carry the image size in PDF units.
 
     PDEFilterArray SetDCTFilterParams(CosDoc cosDoc);
+    PDEFilterArray SetCCITTFaxFilterParams(CosDoc cosDoc);
     ASAtom SetColorSpace(const char *colorSpace);
     ASInt32 SetBPC(ASInt32 bitsPerComp);
 
     static ASAtom sDeviceRGB_K;
+    static ASAtom sDeviceRGBA_K;
+    static ASAtom sDeviceCMYKA_K;
     static ASAtom sDeviceCMYK_K;
     static ASAtom sDeviceGray_K;
 


### PR DESCRIPTION
Add encode and decode paramaters in response to Acrobat error about
insufficient data for an image for some PDF documents, generated when a
CCITT fax decode filter is used.