### PR TITLE
Add README files to describe .NET Core samples

### DIFF
--- a/DotNETCore/Sample_Source/Annotations/README.md
+++ b/DotNETCore/Sample_Source/Annotations/README.md
@@ -1,0 +1,17 @@
+## ***AnnotationCopyPaste***
+Copies annotations from one PDF page and pastes it into another PDF page.
+
+## ***Annotations***
+Collects annotations from a PDF page.
+
+## ***InkAnnotations***
+Creates an ink annotation on a PDF page.
+
+## ***LinkAnnotation***
+Creates a link annotation on a PDF page that navigates the user to another PDF page when clicked.
+
+## ***PolyLineAnnotations***
+Creates a polyline annotation on a PDF page.
+
+## ***PolygonAnnotations***
+Creates a polygon annotation on a PDF page.

--- a/DotNETCore/Sample_Source/ContentCreation/README.md
+++ b/DotNETCore/Sample_Source/ContentCreation/README.md
@@ -1,0 +1,48 @@
+
+## ***AddElements***
+Creates graphic and text elements on a PDF page.
+
+## ***AddHeaderFooter***
+Demonstrates how to create a new PDF document with a Header and Footer on the page.
+
+## ***Clips***
+Creates a clipping path on a PDF page.
+
+## ***CreateBookmarks***
+Creates bookmarks within a PDF document.
+
+## ***GradientShade***
+Creates a shading pattern (gradient) on a PDF Page.
+
+## ***MakeDocWithCalGrayColorSpace***
+Creates a text element on a PDF page using a Calibrated Gray ColorSpace.
+
+## ***MakeDocWithCalRGBColorSpace***
+Creates a text element on a PDF page using a Calibrated RGB ColorSpace.
+
+## ***MakeDocWithDeviceNColorSpace***
+Creates a text element on a PDF page using a DeviceN ColorSpace.
+
+## ***MakeDocWithICCBasedColorSpace***
+Creates a text element on a PDF page using an ICCBased ColorSpace.
+
+## ***MakeDocWithIndexedColorSpace***
+Creates a text element on a PDF page using an Indexed ColorSpace.
+
+## ***MakeDocWithLabColorSpace***
+Creates a text element on a PDF page using a Lab ColorSpace.
+
+## ***MakeDocWithSeparationColorSpace***
+Creates a text element on a PDF page using a Separation ColorSpace.
+
+## ***NameTrees***
+Creates a name tree in a PDF document.
+
+## ***NumberTrees***
+Creates a number tree in a PDF document.
+
+## ***RemoteGoToActions***
+Creates a remote Go-To action as part of a link annotation on a PDF page that navigates to another PDF document when clicked by the user.
+
+## ***WriteNChannelTiff***
+Collects inks present on a PDF page and then rasterizes the page using those ink channels separately and saving it as a multi-channel TIFF (e.g. CMYK).

--- a/DotNETCore/Sample_Source/ContentModification/README.md
+++ b/DotNETCore/Sample_Source/ContentModification/README.md
@@ -1,0 +1,38 @@
+## ***Action***
+Creates an action associated with a link annotation on a PDF page.
+
+## ***AddCollection***
+Adds a collection to a PDF document to turn that document into a PDF Portfolio.
+
+## ***ChangeLayerConfiguration***
+Sets the on/off states for Optional Content Groups (Layers) within a PDF document.
+
+## ***ChangeLinkColors***
+Changes the color of a link annotation on a PDF page.
+
+## ***CreateLayer***
+Demonstrates how to create a new Optional Content (Layer).
+
+## ***ExtendedGraphicStates***
+Creates an extended graphics state and uses it on a PDF page.
+
+## ***FlattenTransparency***
+Flattens elements of transparency in a PDF document.
+
+## ***LaunchActions***
+Creates a launch action associated with a link annotation on a PDF page.
+
+## ***MergePDF***
+Merges two PDF documents together.
+
+## ***PDFObject***
+This sample illustrates how to work with low-level PDF objects.
+
+## ***PageLabels***
+Creates page labels in a PDF document.
+
+## ***UnderlinesAndHighlights***
+Creates Underline and Highlight Annotations on a PDF page.
+
+## ***Watermark***
+Creates a watermark from text or from another PDF on a PDF page.

--- a/DotNETCore/Sample_Source/Display/README.md
+++ b/DotNETCore/Sample_Source/Display/README.md
@@ -1,0 +1,2 @@
+## ***DisplayPDF***
+This sample illustrates how to create a simple PDF Viewer.

--- a/DotNETCore/Sample_Source/DocumentConversion/README.md
+++ b/DotNETCore/Sample_Source/DocumentConversion/README.md
@@ -1,0 +1,17 @@
+## ***ColorConvertDocument***
+This sample illustrates how to convert colors in a PDF document.
+
+## ***CreateDocFromXPS***
+Opens a XPS document and converts it to a PDF document.
+
+## ***Factur-XConverter***
+Converts a PDF document and a Invoice XML document to a Factur-X compliant PDF document.
+
+## ***PDFAConverter***
+Converts a PDF document to a PDF/A compliant document.
+
+## ***PDFXConverter***
+Converts a PDF document to a PDF/X compliant document.
+
+## ***ZUGFeRDConverter***
+Converts a PDF document and a Invoice XML document to a ZUGFeRD compliant PDF document.

--- a/DotNETCore/Sample_Source/DocumentOptimization/README.md
+++ b/DotNETCore/Sample_Source/DocumentOptimization/README.md
@@ -1,0 +1,2 @@
+## ***PDFOptimize***
+Optimizes a PDF document which can make it smaller in size.

--- a/DotNETCore/Sample_Source/Images/README.md
+++ b/DotNETCore/Sample_Source/Images/README.md
@@ -1,0 +1,38 @@
+## ***DocToImages***
+Saves pages of a PDF document as image files.
+
+## ***DrawSeparations***
+Collects Inks present on the PDF page and then rasterizes the page using those Ink channels separately and saving them out as PNG image files.
+
+## ***DrawToBitmap***
+Rasterizes a PDF page to a series of bitmap image files.
+
+## ***EPSSeparations***
+Creates color separations from a PDF page and then saves out each plate as an EPS file.
+
+## ***GetSeparatedImages***
+Collects inks from a PDF page and then creates a collection of grayscale image separations and saves them out as a multi-page TIFF.
+
+## ***ImageEmbedICCProfile***
+Rasterizes PDF pages using a specified ICCProfile and saves them out as image files.
+
+## ***ImageExport***
+Explores the content of PDF pages and when images are found they are saved out as image files.
+
+## ***ImageExtraction***
+Explores the content of PDF pages and when images are found they are saved out as image files.
+
+## ***ImageFromStream***
+Adds an image file read in from a stream to a PDF page.
+
+## ***ImageImport***
+Imports graphics from image files to a PDF page.
+
+## ***ImageResampling***
+Explores the content of PDF pages and when images are found they are resampled to have a new resolution.
+
+## ***ImageSoftMask***
+Adds an image file to be placed on a PDF page and adds another image file to use as its SoftMask image.
+
+## ***RasterizePage***
+Rasterizes the first page of a PDF document.

--- a/DotNETCore/Sample_Source/InformationExtraction/README.md
+++ b/DotNETCore/Sample_Source/InformationExtraction/README.md
@@ -1,0 +1,14 @@
+## ***ListBookmarks***
+Enumerates the bookmarks present in a PDF document.
+
+## ***ListInfo***
+Lists document information metadata that is present in a PDF document.
+
+## ***ListLayers***
+Lists layers (Optional Content) present in a PDF document.
+
+## ***ListPaths***
+Lists paths that are present in a PDF document.
+
+## ***Metadata***
+Lists XMP metadata that is present in a PDF document.

--- a/DotNETCore/Sample_Source/OpticalCharacterRecognition/README.md
+++ b/DotNETCore/Sample_Source/OpticalCharacterRecognition/README.md
@@ -1,0 +1,5 @@
+## ***AddTextToDocument***
+Places recognized text behind the OCR images found on a PDF page.
+
+## ***AddTextToImage***
+Adds an image file to a PDF page, runs OCR on the image, and place the recognized text behind it.

--- a/DotNETCore/Sample_Source/Other/README.md
+++ b/DotNETCore/Sample_Source/Other/README.md
@@ -1,0 +1,5 @@
+## ***MemoryFileSystem***
+This sample illustrates how to utilize memory only for processing temporary files rather than writing to disk.
+
+## ***StreamIO***
+Reads a PDF document from a stream and writes one to a stream.

--- a/DotNETCore/Sample_Source/Printing/README.md
+++ b/DotNETCore/Sample_Source/Printing/README.md
@@ -1,0 +1,5 @@
+## ***PrintPDF***
+Prints a PDF document with a printer, to a file, or to a Postscript file.
+
+## ***PrintPDFGUI***
+Utilizes a printer UI dialog to drive printing of a PDF document.

--- a/DotNETCore/Sample_Source/README.md
+++ b/DotNETCore/Sample_Source/README.md
@@ -1,0 +1,49 @@
+![Datalogics Adobe PDF Library](https://www.datalogics.com/wp-content/uploads/2022/09/Datalogics-Logo-1-e1664565864201.png)
+
+[Datalogics](https://www.datalogics.com)&nbsp;|&nbsp; [Free Trial Download](https://www.datalogics.com/adobe-pdf-library/) &nbsp;|&nbsp; [Documentation](https://dev.datalogics.com/) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp;|&nbsp;[NuGet](https://www.nuget.org/profiles/Datalogics)
+
+<br>
+
+# .NET Core Sample Programs
+## ***Introduction***
+The Adobe PDF Library (APDFL) is an Application Programming Interface (API) designed to allow programmers to work with the Adobe PDF file format.  The APDFL Software Development Kit (SDK) provides a method for software developers and vendors to build their own third-party systems that allow them to create, change, process, review, and otherwise work with PDF files. The Library is the same one that Adobe Acrobat is based on.
+
+Datalogics provides a .NET Core interface to the Adobe PDF Library. This Interface offers a set of modules for the Library that allow programmers working in C# or other languages supported by .NET Core to take advantage of Adobe PDF Library tools and resources. This interface encapsulates the original Adobe PDF Library; the interface allows you to work with the original core library functions directly, and seamlessly, in .NET Core.
+
+## ***The Sample Programs***
+The Adobe PDF Library supports all of the languages that work with .NET Core, including C# and Visual Basic. The Adobe PDF Library provides a set of sample C# program files, stored under /DotNETCore/Sample_Source.
+
+Most of the code samples in APDFL are designed to demonstrate how an API works by completing a simple programming task. You can open the sample .NET Core program files and review them in Microsoft Visual Studio 2019, Visual Studio Code, or a text editor on a Linux or macOS platform for reference, or you can copy parts of this code to use in your own programs.  You can also build and run sample programs from your Operating System command line.
+
+For example, you would access this directory, where the sample program files are stored, to build and run the sample:
+
+```C:\APDFL18\DotNETCore\Sample_Source\Text\```
+
+We assume a basic level of technical understanding of the PDF file format, though we seek to review the features of each of these sample programs carefully.
+
+Many of these sample programs automatically generate an output file or set of files.  These output files, generally PDF or graphics files (JPG or BMP), are stored in the directory where the application has been run. If you run a sample program a second or third time, it will overwrite any output files that were created and stored earlier.  However, if you run a sample program, generate a PDF output file, and then open that PDF file and try to run that sample program again, you will see an error message.  The program will not be able to overwrite an existing output file if that file is currently open in Adobe Reader or Adobe Acrobat.
+
+Note that the Forms Extension plug-in sample programs provided with the .NET Interface with the Adobe PDF Library are not available with .NET Core.
+
+## ***Building and Running .NET Core Sample Programs***
+Start from your DotNETCore directory, and change to the Sample_Source directory for the program you want to work with. Here is an example:
+
+```cd Sample_Source/Images/RasterizePage```
+
+Build a sample project file using the Debug configuration. Use the dotnet program command, which is used with .NET Core to build projects and run applications:
+
+```dotnet build -c Debug ./RasterizePage.csproj /p:Platform=[x64|ARM64]```
+
+If you want to build a Release use this command syntax instead:
+
+```dotnet build -c Release ./RasterizePage.csproj /p:Platform=[x64|ARM64]```
+
+Change to the **Binaries** directory:
+
+```cd ../../../Binaries```
+
+Run the application by specifying the .dll file. Note the .dll file is the .NET Core executable for all platforms:
+
+```dotnet ./RasterizePage.dll```
+
+**Note**: Adobe PDF Library dependencies are found in the DotNETCore/Binaries directory. Samples are setup to write their .NET Core .dll files to this directory along with any other dependencies, such as SkiaSharp.

--- a/DotNETCore/Sample_Source/Security/README.md
+++ b/DotNETCore/Sample_Source/Security/README.md
@@ -1,0 +1,5 @@
+## ***AddRegexRedaction***
+Uses a regular expression to find a specified phrase of text in a PDF document and then redacts that text.
+
+## ***Redactions***
+Finds a specified phrase of text in a PDF document and then redacts that text.

--- a/DotNETCore/Sample_Source/Text/README.md
+++ b/DotNETCore/Sample_Source/Text/README.md
@@ -1,0 +1,43 @@
+## ***AddGlyphs***
+Adds specific glyphs as text to a PDF page.
+
+## ***AddUnicodeText***
+Adds Unicode text to a PDF page.
+
+## ***AddVerticalText***
+Adds text in vertical writing mode to a PDF page.
+
+## ***ExtractAcroformFieldData***
+Extracts text from the AcroForm fields in a PDF document.  It displays the output in the console window and also saves the text to a JSON file. It is useful for those who work with fillable forms in PDFs and need to extract the text within the form to use in a different format.
+
+## ***ExtractCJKTextByPatternMatch***
+This sample allows searching for Unicode characters such as Chinese, Japanese, and Korean (CJK). It is the same as ExtractTextByPatternMatch, but searches for a specific string of text in Korean.
+
+## ***ExtractTextByPatternMatch***
+Searches for patterns that match text based on a given regular expression. For this sample, we search for phone numbers and save the results in a text file.
+
+## ***ExtractTextByRegion***
+Extracts text from a specific region of a page in a PDF document and saves the text to a file. Let’s say you or one of your clients has thousands of invoices with the same format and you need to pull data out of a specific region all at once (i.e., all of the invoice numbers), this sample can help with that.
+
+## ***ExtractTextFromAnnotations***
+Extracts text from the annotations in a PDF document and saves the text to a JSON file indicating what type of annotation and the text within it. If you need consolidate all the notes and feedback that were added as annotations in your PDFs, this function can help you pull out that data for easy viewing and/or printing.
+
+## ***ExtractTextFromMultiRegions***
+Processes example invoice PDF files in a folder that share the same page layout and extracts text from specific regions of its pages and saves the text to a CSV file.  All the invoice numbers, dates, order numbers, customer IDs, and totals from the invoices in the folder are saved in convenient CSV format.
+
+## ***ExtractTextPreservingStyleAndPositionInfo***
+Extracts text along with details about the text such as quads, font, font-size, color, and styles from a PDF document and saves the text to a JSON file.
+
+## ***ListWords***
+Extracts text from a PDF document and displays the extracted words.
+
+## ***RegexExtractText***
+Uses a regular expression to find a specified phrase of text in a PDF document.
+
+## ***RegexTextSearch***
+Searches for phrases or text patterns in a PDF input document. It supplies sample regular expressions to use in searching for phone numbers, email addresses, or URLs, and you can use them or create your own. You can search the entire PDF document or provide a page range for your search. The program generates an output PDF document that matches the input file except that the search content appears highlighted.  You can enter the name of the input file you plan to use, and the name of the output file. The sample uses [PDDocTextFinder](https://dev.datalogics.com/adobe-pdf-library/adobe-pdf-library-c-language-interface/working-with-the-adobe-pdf-library/searching-for-content-in-a-pdf-document/) to find instances of a phrase or pattern in a PDF input document.
+
+The sample normally highlights search text with a box that surrounds the entire phrase found. But if the search text is on multiple lines, or if the font changes within the phrase, the content appears in multiple boxes.
+
+## ***TextExtract***
+Extracts text from a tagged and untagged PDF document.


### PR DESCRIPTION
Brief descriptions in a README.md file have been added for .NET Core samples.  Developer's can now easily search for a sample that can aide them with code in their area of interest.