### PR TITLE
Update DotNet samples to include 30-day use key

### DIFF
--- a/DotNET/Sample_Source/Annotations/Annotations/Annotations.cs
+++ b/DotNET/Sample_Source/Annotations/Annotations/Annotations.cs
@@ -22,6 +22,9 @@ namespace Annotations
         {
             Console.WriteLine("Annotations Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Annotations/InkAnnotations/InkAnnotations.cs
+++ b/DotNET/Sample_Source/Annotations/InkAnnotations/InkAnnotations.cs
@@ -25,6 +25,9 @@ namespace InkAnnotations
         static void Main()
         {
             Console.WriteLine("InkAnnotations Sample:");
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Annotations/LinkAnnotation/LinkAnnotation.cs
+++ b/DotNET/Sample_Source/Annotations/LinkAnnotation/LinkAnnotation.cs
@@ -24,6 +24,9 @@ namespace LinkAnnotations
         {
             Console.WriteLine("LinkAnnotations Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Annotations/PolyLineAnnotations/PolyLineAnnotations.cs
+++ b/DotNET/Sample_Source/Annotations/PolyLineAnnotations/PolyLineAnnotations.cs
@@ -22,6 +22,9 @@ namespace PolyLineAnnotations
         static void Main(string[] args)
         {
             Console.WriteLine("PolyLineAnnotation Sample:");
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Annotations/PolygonAnnotations/PolygonAnnotations.cs
+++ b/DotNET/Sample_Source/Annotations/PolygonAnnotations/PolygonAnnotations.cs
@@ -22,6 +22,9 @@ namespace PolygonAnnotations
         static void Main(string[] args)
         {
             Console.WriteLine("PolygonAnnotation Sample:");
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/AddElements/AddElements.cs
+++ b/DotNET/Sample_Source/ContentCreation/AddElements/AddElements.cs
@@ -24,6 +24,9 @@ namespace AddElements
         {
             Console.WriteLine("AddElements Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/AddHeaderFooter/AddHeaderFooter.cs
+++ b/DotNET/Sample_Source/ContentCreation/AddHeaderFooter/AddHeaderFooter.cs
@@ -29,6 +29,9 @@ namespace AddHeaderFooter
 
             Console.WriteLine("AddHeaderFooter Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (Library lib = new Library())
             {
                 String sOutput = "../AddHeaderFooter-out.pdf";

--- a/DotNET/Sample_Source/ContentCreation/Clips/Clips.cs
+++ b/DotNET/Sample_Source/ContentCreation/Clips/Clips.cs
@@ -24,6 +24,9 @@ namespace Clips
         {
             Console.WriteLine("Clips Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/CreateBookmarks/CreateBookmarks.cs
+++ b/DotNET/Sample_Source/ContentCreation/CreateBookmarks/CreateBookmarks.cs
@@ -91,6 +91,9 @@ namespace CreateBookmarks
         {
             Console.WriteLine("CreateBookmarks Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/GradientShade/GradientShade.cs
+++ b/DotNET/Sample_Source/ContentCreation/GradientShade/GradientShade.cs
@@ -23,6 +23,9 @@ namespace GradientShade
         {
             Console.WriteLine("GradientShade Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithCalGrayColorSpace/MakeDocWithCalGrayColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithCalGrayColorSpace/MakeDocWithCalGrayColorSpace.cs
@@ -20,6 +20,9 @@ namespace MakeDocWithCalGrayColorSpace
     {
         static void Main(string[] args)
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithCalRGBColorSpace/MakeDocWithCalRGBColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithCalRGBColorSpace/MakeDocWithCalRGBColorSpace.cs
@@ -21,6 +21,9 @@ namespace MakeDocWithCalRGBColorSpace
     {
         static void Main(string[] args)
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithDeviceNColorSpace/MakeDocWithDeviceNColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithDeviceNColorSpace/MakeDocWithDeviceNColorSpace.cs
@@ -20,6 +20,9 @@ namespace MakeDocWithDeviceNColorSpace
     {
         static void Main(string[] args)
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithICCBasedColorSpace/MakeDocWithICCBasedColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithICCBasedColorSpace/MakeDocWithICCBasedColorSpace.cs
@@ -20,6 +20,9 @@ namespace MakeDocWithICCBasedColorSpace
     {
         static void Main(string[] args)
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithIndexedColorSpace/MakeDocWithIndexedColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithIndexedColorSpace/MakeDocWithIndexedColorSpace.cs
@@ -24,6 +24,9 @@ namespace MakeDocWithIndexedColorSpace
     {
         static void Main(string[] args)
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithLabColorSpace/MakeDocWithLabColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithLabColorSpace/MakeDocWithLabColorSpace.cs
@@ -23,6 +23,9 @@ namespace MakeDocWithLabColorSpace
     {
         static void Main(string[] args)
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithSeparationColorSpace/MakeDocWithSeparationColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithSeparationColorSpace/MakeDocWithSeparationColorSpace.cs
@@ -20,6 +20,9 @@ namespace MakeDocWithSeparationColorSpace
     {
         static void Main(string[] args)
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/NameTrees/NameTrees.cs
+++ b/DotNET/Sample_Source/ContentCreation/NameTrees/NameTrees.cs
@@ -26,6 +26,9 @@ namespace NameTrees
         static void Main()
         {
             Console.WriteLine("NameTree Sample:");
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/NumberTrees/NumberTrees.cs
+++ b/DotNET/Sample_Source/ContentCreation/NumberTrees/NumberTrees.cs
@@ -26,6 +26,9 @@ namespace NumberTrees
         static void Main()
         {
             Console.WriteLine("NumberTree Sample:");
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/RemoteGoToActions/RemoteGoToActions.cs
+++ b/DotNET/Sample_Source/ContentCreation/RemoteGoToActions/RemoteGoToActions.cs
@@ -25,6 +25,9 @@ namespace RemoteGoToActions
     {
         static void Main(string[] args)
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentCreation/WriteNChannelTiff/WriteNChannelTiff.cs
+++ b/DotNET/Sample_Source/ContentCreation/WriteNChannelTiff/WriteNChannelTiff.cs
@@ -24,6 +24,9 @@ namespace WriteNChannelTiff
         {
             Console.WriteLine("WriteNChannelTiff Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/Action/Action.cs
+++ b/DotNET/Sample_Source/ContentModification/Action/Action.cs
@@ -20,6 +20,9 @@ namespace Action
         {
             Console.WriteLine("Actions Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/AddCollection/AddCollection.cs
+++ b/DotNET/Sample_Source/ContentModification/AddCollection/AddCollection.cs
@@ -25,6 +25,9 @@ namespace AddCollection
         {
             Console.WriteLine("AddCollection Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.cs
+++ b/DotNET/Sample_Source/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.cs
@@ -29,6 +29,9 @@ namespace ChangeLayerConfiguration
         {
             Console.WriteLine("ChangeLayerConfiguration Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/ChangeLinkColors/ChangeLinkColors.cs
+++ b/DotNET/Sample_Source/ContentModification/ChangeLinkColors/ChangeLinkColors.cs
@@ -27,6 +27,9 @@ namespace ChangeLinkColors
         {
             Console.WriteLine("ChangeLinkColors Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/CreateLayer/CreateLayer.cs
+++ b/DotNET/Sample_Source/ContentModification/CreateLayer/CreateLayer.cs
@@ -26,6 +26,9 @@ namespace CreateLayer
         {
             Console.WriteLine("CreateLayer Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.cs
+++ b/DotNET/Sample_Source/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.cs
@@ -187,6 +187,9 @@ namespace ExtendedGraphicStates
         static void Main(string[] args)
         {
             Console.WriteLine("ExtendedGraphicStates Sample:");
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/FlattenTransparency/FlattenTransparency.cs
+++ b/DotNET/Sample_Source/ContentModification/FlattenTransparency/FlattenTransparency.cs
@@ -31,6 +31,9 @@ namespace FlattenTransparency
         {
             Console.WriteLine("FlattenTransparency sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/LaunchActions/LaunchActions.cs
+++ b/DotNET/Sample_Source/ContentModification/LaunchActions/LaunchActions.cs
@@ -19,6 +19,9 @@ namespace LaunchActions
     {
         static void Main(string[] args)
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/MergePDF/MergePDF.cs
+++ b/DotNET/Sample_Source/ContentModification/MergePDF/MergePDF.cs
@@ -22,6 +22,9 @@ namespace MergePDF
         {
             Console.WriteLine("MergePDF Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/PDFObject/PDFObject.cs
+++ b/DotNET/Sample_Source/ContentModification/PDFObject/PDFObject.cs
@@ -26,6 +26,9 @@ namespace PDFObject
         {
             Console.WriteLine("PDFObject Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/PageLabels/PageLabels.cs
+++ b/DotNET/Sample_Source/ContentModification/PageLabels/PageLabels.cs
@@ -26,6 +26,9 @@ namespace PageLabels
         {
             Console.WriteLine("Page Labels Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.cs
+++ b/DotNET/Sample_Source/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.cs
@@ -23,6 +23,9 @@ namespace UnderlinesAndHighlights
         {
             Console.WriteLine("UnderlinesAndHighlights Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/ContentModification/Watermark/Watermark.cs
+++ b/DotNET/Sample_Source/ContentModification/Watermark/Watermark.cs
@@ -27,6 +27,9 @@ namespace Watermark
         static void Main(string[] args)
         {
             Console.WriteLine("Watermark Sample:");
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Display/DisplayPDF/DisplayPDF.cs
+++ b/DotNET/Sample_Source/Display/DisplayPDF/DisplayPDF.cs
@@ -24,6 +24,9 @@ namespace DisplayPDF
         [STAThread]
         static void Main()
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (Library lib = new Library())
             {                    
                 Application.EnableVisualStyles();

--- a/DotNET/Sample_Source/DocumentConversion/ColorConvertDocument/ColorConvertDocument.cs
+++ b/DotNET/Sample_Source/DocumentConversion/ColorConvertDocument/ColorConvertDocument.cs
@@ -30,6 +30,9 @@ namespace ColorConvertDocument
         {
             Console.WriteLine("ColorConvertDocument Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             List<string> paths = new List<string>();
             paths.Add(Library.ResourceDirectory + "Fonts/");
 

--- a/DotNET/Sample_Source/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.cs
+++ b/DotNET/Sample_Source/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.cs
@@ -24,6 +24,9 @@ namespace CreateDocFromXPS
         {
             Console.WriteLine("CreateDocFromXPS sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using(Library lib = new Library())
             {
 

--- a/DotNET/Sample_Source/DocumentConversion/Factur-XConverter/Factur-XConverter.cs
+++ b/DotNET/Sample_Source/DocumentConversion/Factur-XConverter/Factur-XConverter.cs
@@ -28,6 +28,9 @@ class FacturXConverter
         {
             Console.WriteLine("Factur-XConverter Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // Initialize the Library
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/DocumentConversion/PDFAConverter/PDFAConverter.cs
+++ b/DotNET/Sample_Source/DocumentConversion/PDFAConverter/PDFAConverter.cs
@@ -23,6 +23,9 @@ namespace PDFAConverter
         {
             Console.WriteLine("PDFAConverter Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/DocumentConversion/PDFXConverter/PDFXConverter.cs
+++ b/DotNET/Sample_Source/DocumentConversion/PDFXConverter/PDFXConverter.cs
@@ -26,6 +26,9 @@ namespace PDFXConverter
         {
             Console.WriteLine("PDFXConverter Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (Library lib = new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.cs
+++ b/DotNET/Sample_Source/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.cs
@@ -23,7 +23,10 @@ namespace ZUGFeRDConverter
             Console.WriteLine("ZUGFeRDConverter Sample:");
 
             //Initialize the Library
-            // ReSharper disable once UnusedVariable
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
+           // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/DocumentOptimization/PDFOptimize/PDFOptimize.cs
+++ b/DotNET/Sample_Source/DocumentOptimization/PDFOptimize/PDFOptimize.cs
@@ -29,6 +29,9 @@ namespace PDFOptimize
         {
             Console.WriteLine("PDF Optimizer:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Images/DocToImages/DocToImages.cs
+++ b/DotNET/Sample_Source/Images/DocToImages/DocToImages.cs
@@ -1074,6 +1074,9 @@ namespace DocToImages
                 Environment.Exit(1);
             }
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library(options.getfontdirs()))
             {

--- a/DotNET/Sample_Source/Images/DrawSeparations/DrawSeparations.cs
+++ b/DotNET/Sample_Source/Images/DrawSeparations/DrawSeparations.cs
@@ -26,6 +26,9 @@ namespace DrawSeparations
 
             Console.WriteLine("DrawSeparations Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Images/DrawToBitmap/DrawToBitmap.cs
+++ b/DotNET/Sample_Source/Images/DrawToBitmap/DrawToBitmap.cs
@@ -186,6 +186,9 @@ namespace DrawToBitmap
 
             try
             {
+                // This is the 30 day evaluation license key
+                Library.LicenseKey = "3011-6479-7180-0953";
+
                 // ReSharper disable once UnusedVariable
                 using (Library lib = new Library())
                 {

--- a/DotNET/Sample_Source/Images/EPSSeparations/EPSSeparations.cs
+++ b/DotNET/Sample_Source/Images/EPSSeparations/EPSSeparations.cs
@@ -25,6 +25,9 @@ namespace EPSSeparations
         {
             Console.WriteLine("EPS Separations Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Images/GetSeparatedImages/GetSeparatedImages.cs
+++ b/DotNET/Sample_Source/Images/GetSeparatedImages/GetSeparatedImages.cs
@@ -35,6 +35,9 @@ namespace GetSeparatedImages
 
             Console.WriteLine("Input file: " + sInput + ", will write to " + sOutput);
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.cs
+++ b/DotNET/Sample_Source/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.cs
@@ -90,6 +90,9 @@ namespace ImageEmbedICCProfile
 
             Console.WriteLine("Image Embed ICC Profile sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Images/ImageExport/ImageExport.cs
+++ b/DotNET/Sample_Source/Images/ImageExport/ImageExport.cs
@@ -147,6 +147,9 @@ namespace ImageExport
         {
             Console.WriteLine("Image Export sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Images/ImageExtraction/ImageExtraction.cs
+++ b/DotNET/Sample_Source/Images/ImageExtraction/ImageExtraction.cs
@@ -71,6 +71,9 @@ namespace ImageExtraction
 
             Console.WriteLine("ImageExtraction Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Images/ImageFromStream/ImageFromStream.cs
+++ b/DotNET/Sample_Source/Images/ImageFromStream/ImageFromStream.cs
@@ -31,6 +31,9 @@ namespace ImageFromStream
 
             Console.WriteLine("ImageFromStream Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Images/ImageImport/ImageImport.cs
+++ b/DotNET/Sample_Source/Images/ImageImport/ImageImport.cs
@@ -23,6 +23,9 @@ namespace ImageImport
         static void Main(string[] args)
         {
             Console.WriteLine("Import Images Sample:");
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Images/ImageResampling/ImageResampling.cs
+++ b/DotNET/Sample_Source/Images/ImageResampling/ImageResampling.cs
@@ -76,6 +76,9 @@ namespace ImageResampling
         {
             Console.WriteLine("ImageResampling Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Images/ImageSoftMask/ImageSoftMask.cs
+++ b/DotNET/Sample_Source/Images/ImageSoftMask/ImageSoftMask.cs
@@ -25,6 +25,9 @@ namespace ImageSoftMask
         {
             Console.WriteLine("Image Soft Mask sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Images/RasterizePage/RasterizePage.cs
+++ b/DotNET/Sample_Source/Images/RasterizePage/RasterizePage.cs
@@ -39,6 +39,9 @@ namespace RasterizePage
 
             Console.WriteLine("RasterizePage Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/InformationExtraction/ListBookmarks/ListBookmarks.cs
+++ b/DotNET/Sample_Source/InformationExtraction/ListBookmarks/ListBookmarks.cs
@@ -50,6 +50,9 @@ namespace ListBookmarks
         {
             Console.WriteLine("ListBookmarks Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/InformationExtraction/ListInfo/ListInfo.cs
+++ b/DotNET/Sample_Source/InformationExtraction/ListInfo/ListInfo.cs
@@ -25,6 +25,9 @@ namespace ListInfo
         {
             Console.WriteLine("ListInfo Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/InformationExtraction/ListLayers/ListLayers.cs
+++ b/DotNET/Sample_Source/InformationExtraction/ListLayers/ListLayers.cs
@@ -23,6 +23,9 @@ namespace ListLayers
         {
             Console.WriteLine("ListLayers Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/InformationExtraction/ListPaths/ListPaths.cs
+++ b/DotNET/Sample_Source/InformationExtraction/ListPaths/ListPaths.cs
@@ -24,6 +24,9 @@ namespace ListPaths
         {
             Console.WriteLine("ListLayers Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/InformationExtraction/Metadata/Metadata.cs
+++ b/DotNET/Sample_Source/InformationExtraction/Metadata/Metadata.cs
@@ -24,6 +24,9 @@ namespace Metadata
     {
         static void Main(string[] args)
         {
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.cs
+++ b/DotNET/Sample_Source/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.cs
@@ -55,6 +55,9 @@ namespace AddTextToDocument
         {
             Console.WriteLine("AddTextToDocument Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.cs
+++ b/DotNET/Sample_Source/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.cs
@@ -24,6 +24,9 @@ namespace AddTextToImage
         {
             Console.WriteLine("AddTextToImage Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Other/MemoryFileSystem/MemoryFileSystem.cs
+++ b/DotNET/Sample_Source/Other/MemoryFileSystem/MemoryFileSystem.cs
@@ -24,6 +24,9 @@ namespace MemoryFileSystem
         {
             Console.WriteLine("MemoryFileSystem Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (Library lib = new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Other/StreamIO/StreamIO.cs
+++ b/DotNET/Sample_Source/Other/StreamIO/StreamIO.cs
@@ -120,6 +120,9 @@ namespace StreamIO
         {
             StreamIOSample sample = new StreamIOSample();
             Console.WriteLine("StreamIO Sample:");
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Printing/PrintPDF/PrintPDF.cs
+++ b/DotNET/Sample_Source/Printing/PrintPDF/PrintPDF.cs
@@ -86,6 +86,9 @@ namespace PrintPDF
 
             try
             {
+                // This is the 30 day evaluation license key
+                Library.LicenseKey = "3011-6479-7180-0953";
+
                 // Printing may fail for reasons that have nothing to do with APDFL.
                 // PDF documents may contain material that cannot be printed, etc. Given
                 // that, it's always best to expect the printing step to fail and take

--- a/DotNET/Sample_Source/Printing/PrintPDFGUI/PrintPDFForm.cs
+++ b/DotNET/Sample_Source/Printing/PrintPDFGUI/PrintPDFForm.cs
@@ -29,6 +29,9 @@ namespace PrintPDFGUI
         {
             try
             {
+                // This is the 30 day evaluation license key
+                Library.LicenseKey = "3011-6479-7180-0953";
+
                 using (Library lib = new Library())
                 {
                     using (Document doc = new Document(textBox1.Text))

--- a/DotNET/Sample_Source/Security/AddRegexRedaction/AddRegexRedaction.cs
+++ b/DotNET/Sample_Source/Security/AddRegexRedaction/AddRegexRedaction.cs
@@ -21,6 +21,9 @@ namespace AddRegexRedaction
         {
             Console.WriteLine("AddRegexRedaction Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Security/Redactions/Redactions.cs
+++ b/DotNET/Sample_Source/Security/Redactions/Redactions.cs
@@ -24,6 +24,9 @@ namespace Redactions
         {
             Console.WriteLine("Redactions Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Text/AddGlyphs/AddGlyphs.cs
+++ b/DotNET/Sample_Source/Text/AddGlyphs/AddGlyphs.cs
@@ -24,6 +24,9 @@ namespace AddGlyphs
         {
             Console.WriteLine("AddGlyphs Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Text/AddUnicodeText/AddUnicodeText.cs
+++ b/DotNET/Sample_Source/Text/AddUnicodeText/AddUnicodeText.cs
@@ -24,6 +24,9 @@ namespace AddUnicodeText
         {
             Console.WriteLine("AddUnicodeText Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Text/AddVerticalText/AddVerticalText.cs
+++ b/DotNET/Sample_Source/Text/AddVerticalText/AddVerticalText.cs
@@ -25,6 +25,9 @@ namespace AddVerticalText
         {
             Console.WriteLine("AddVerticalText Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.cs
+++ b/DotNET/Sample_Source/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.cs
@@ -32,6 +32,9 @@ namespace ExtractAcroFormFieldData
         {
             Console.WriteLine("ExtractAcroFormFieldData Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Text/ExtractCJKTextByPatternMatch/ExtractCJKTextByPatternMatch.cs
+++ b/DotNET/Sample_Source/Text/ExtractCJKTextByPatternMatch/ExtractCJKTextByPatternMatch.cs
@@ -20,6 +20,9 @@ namespace ExtractCJKTextByPatternMatch
         {
             Console.WriteLine("ExtractCJKTextByPatternMatch Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Text/ExtractTextByPatternMatch/ExtractTextByPatternMatch.cs
+++ b/DotNET/Sample_Source/Text/ExtractTextByPatternMatch/ExtractTextByPatternMatch.cs
@@ -20,6 +20,9 @@ namespace ExtractTextByPatternMatch
         {
             Console.WriteLine("ExtractTextByPatternMatch Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Text/ExtractTextByRegion/ExtractTextByRegion.cs
+++ b/DotNET/Sample_Source/Text/ExtractTextByRegion/ExtractTextByRegion.cs
@@ -32,6 +32,9 @@ namespace ExtractTextByRegion
         {
             Console.WriteLine("ExtractTextByRegion Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.cs
+++ b/DotNET/Sample_Source/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.cs
@@ -34,6 +34,9 @@ namespace ExtractTextFromAnnotations
         {
             Console.WriteLine("Annotations Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.cs
+++ b/DotNET/Sample_Source/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.cs
@@ -44,6 +44,9 @@ namespace ExtractTextFromMultiRegions
         {
             Console.WriteLine("ExtractTextFromMultiRegions Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.cs
+++ b/DotNET/Sample_Source/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.cs
@@ -28,6 +28,9 @@ namespace ExtractTextPreservingStyleAndPositionInfo
         {
             Console.WriteLine("ExtractTextPreservingStyleAndPositionInfo Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Text/ListWords/ListWords.cs
+++ b/DotNET/Sample_Source/Text/ListWords/ListWords.cs
@@ -24,6 +24,9 @@ namespace ListWords
         {
             Console.WriteLine("ListWords Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {

--- a/DotNET/Sample_Source/Text/RegexExtractText/RegexExtractText.cs
+++ b/DotNET/Sample_Source/Text/RegexExtractText/RegexExtractText.cs
@@ -94,6 +94,9 @@ namespace RegexExtractText
         {
             Console.WriteLine("RegexExtractText Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Text/RegexTextSearch/RegexTextSearch.cs
+++ b/DotNET/Sample_Source/Text/RegexTextSearch/RegexTextSearch.cs
@@ -21,6 +21,9 @@ namespace RegexTextSearch
         {
             Console.WriteLine("RegexTextSearch Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             using (new Library())
             {
                 Console.WriteLine("Initialized the library.");

--- a/DotNET/Sample_Source/Text/TextExtract/TextExtract.cs
+++ b/DotNET/Sample_Source/Text/TextExtract/TextExtract.cs
@@ -25,6 +25,9 @@ namespace TextExtract
         {
             Console.WriteLine("TextExtract Sample:");
 
+            // This is the 30 day evaluation license key
+            Library.LicenseKey = "3011-6479-7180-0953";
+
             // ReSharper disable once UnusedVariable
             using (Library lib = new Library())
             {


### PR DESCRIPTION
Added a default key into the DotNet sample projects. Which removes the need to manually add a key to start working with these samples for the first 30 days.
