### PR TITLE
Update Transparency Quality setting and remove 30-day license text

### DIFF
--- a/CPlusPlus/Sample_Source/Printing/PDFPrintDefault/PDFPrintDefault.cpp
+++ b/CPlusPlus/Sample_Source/Printing/PDFPrintDefault/PDFPrintDefault.cpp
@@ -173,12 +173,14 @@ int main(int argc, char **argv) {
         userParams.doOPP = false;
 
         userParams.farEastFontOpt = 0;
-        userParams.transQuality = 5;
         userParams.forceGDIPrint =
             false; /* When true, we will print via the GDI interface, even if the selected printer supports postscript. */
 
         std::cout << "Sending to the printer " << userParams.deviceNameW << std::endl;
 #endif
+
+        userParams.transQuality = 100;
+
 #ifdef UNIX_ENV
         // print to the printer lp0, suppress reporting job number to stdout.
         userParams.command = "lp -s";

--- a/CPlusPlus/Sample_Source/_Common/SetupPrintParams.cpp
+++ b/CPlusPlus/Sample_Source/_Common/SetupPrintParams.cpp
@@ -39,7 +39,7 @@ void SetupPDPrintParams(PDPrintParams psParams) {
                                // duplex is true, and number of pages is odd.)
     psParams->doOPP = false; // When true, CMYK colors will “mix” in the manner of the OP blending model.
     psParams->transparencyQuality =
-        false; // Echoed in PDFLPrintUserParams as the transQuaility attribute.
+        100; // Echoed in PDFLPrintUserParams as the transQuality attribute.
                // Used to establish how much time/resources should be applied to flattening
                // transparency while printing the page. At the lowest values, this will
                // basically render all transparent areas as bitmaps.
@@ -308,9 +308,6 @@ void SetupPDFLPrintUserParams(PDFLPrintUserParams userParams) {
     userParams->farEastFontOpt =
         false; // Controls if very large fonts are to be downloaded or not. This is effective only for PostScript.
 
-    userParams->transQuality = false; // Echoes the attribute transparencyQuality in the PDPrintParamsRec.
-                                      // Controls how the flattener will remove transparency from a page.
-
     userParams->startResult =
         0; // Should be set to the jobId returned by StartDoc, if the application does the StartDoc.
     userParams->pDC = NULL; // Will be filled in by APDFL to the DeviceContext for the currently selected printer.
@@ -324,6 +321,8 @@ void SetupPDFLPrintUserParams(PDFLPrintUserParams userParams) {
                                        // printer selected is capable of supporting PostScript.
 
 #endif
+
+    userParams->transQuality = 5; // Controls how the flattener will remove transparency from a page.
 
     userParams->paperWidth =
         kPDPrintUseMediaBox; // Used to select paper.  The value kPDPrintUseMediaBox will cause the

--- a/DotNET/Sample_Source/Annotations/Annotations/Annotations.cs
+++ b/DotNET/Sample_Source/Annotations/Annotations/Annotations.cs
@@ -22,7 +22,7 @@ namespace Annotations
         {
             Console.WriteLine("Annotations Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Annotations/InkAnnotations/InkAnnotations.cs
+++ b/DotNET/Sample_Source/Annotations/InkAnnotations/InkAnnotations.cs
@@ -25,7 +25,8 @@ namespace InkAnnotations
         static void Main()
         {
             Console.WriteLine("InkAnnotations Sample:");
-            // This is the 30 day evaluation license key
+
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Annotations/LinkAnnotation/LinkAnnotation.cs
+++ b/DotNET/Sample_Source/Annotations/LinkAnnotation/LinkAnnotation.cs
@@ -24,7 +24,7 @@ namespace LinkAnnotations
         {
             Console.WriteLine("LinkAnnotations Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Annotations/PolyLineAnnotations/PolyLineAnnotations.cs
+++ b/DotNET/Sample_Source/Annotations/PolyLineAnnotations/PolyLineAnnotations.cs
@@ -22,7 +22,8 @@ namespace PolyLineAnnotations
         static void Main(string[] args)
         {
             Console.WriteLine("PolyLineAnnotation Sample:");
-            // This is the 30 day evaluation license key
+
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Annotations/PolygonAnnotations/PolygonAnnotations.cs
+++ b/DotNET/Sample_Source/Annotations/PolygonAnnotations/PolygonAnnotations.cs
@@ -22,7 +22,8 @@ namespace PolygonAnnotations
         static void Main(string[] args)
         {
             Console.WriteLine("PolygonAnnotation Sample:");
-            // This is the 30 day evaluation license key
+
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/AddElements/AddElements.cs
+++ b/DotNET/Sample_Source/ContentCreation/AddElements/AddElements.cs
@@ -24,7 +24,7 @@ namespace AddElements
         {
             Console.WriteLine("AddElements Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/AddHeaderFooter/AddHeaderFooter.cs
+++ b/DotNET/Sample_Source/ContentCreation/AddHeaderFooter/AddHeaderFooter.cs
@@ -29,7 +29,7 @@ namespace AddHeaderFooter
 
             Console.WriteLine("AddHeaderFooter Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (Library lib = new Library())

--- a/DotNET/Sample_Source/ContentCreation/Clips/Clips.cs
+++ b/DotNET/Sample_Source/ContentCreation/Clips/Clips.cs
@@ -24,7 +24,7 @@ namespace Clips
         {
             Console.WriteLine("Clips Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/CreateBookmarks/CreateBookmarks.cs
+++ b/DotNET/Sample_Source/ContentCreation/CreateBookmarks/CreateBookmarks.cs
@@ -91,7 +91,7 @@ namespace CreateBookmarks
         {
             Console.WriteLine("CreateBookmarks Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/GradientShade/GradientShade.cs
+++ b/DotNET/Sample_Source/ContentCreation/GradientShade/GradientShade.cs
@@ -23,7 +23,7 @@ namespace GradientShade
         {
             Console.WriteLine("GradientShade Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithCalGrayColorSpace/MakeDocWithCalGrayColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithCalGrayColorSpace/MakeDocWithCalGrayColorSpace.cs
@@ -20,7 +20,7 @@ namespace MakeDocWithCalGrayColorSpace
     {
         static void Main(string[] args)
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithCalRGBColorSpace/MakeDocWithCalRGBColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithCalRGBColorSpace/MakeDocWithCalRGBColorSpace.cs
@@ -21,7 +21,7 @@ namespace MakeDocWithCalRGBColorSpace
     {
         static void Main(string[] args)
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithDeviceNColorSpace/MakeDocWithDeviceNColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithDeviceNColorSpace/MakeDocWithDeviceNColorSpace.cs
@@ -20,7 +20,7 @@ namespace MakeDocWithDeviceNColorSpace
     {
         static void Main(string[] args)
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithICCBasedColorSpace/MakeDocWithICCBasedColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithICCBasedColorSpace/MakeDocWithICCBasedColorSpace.cs
@@ -20,7 +20,7 @@ namespace MakeDocWithICCBasedColorSpace
     {
         static void Main(string[] args)
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithIndexedColorSpace/MakeDocWithIndexedColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithIndexedColorSpace/MakeDocWithIndexedColorSpace.cs
@@ -24,7 +24,7 @@ namespace MakeDocWithIndexedColorSpace
     {
         static void Main(string[] args)
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithLabColorSpace/MakeDocWithLabColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithLabColorSpace/MakeDocWithLabColorSpace.cs
@@ -23,7 +23,7 @@ namespace MakeDocWithLabColorSpace
     {
         static void Main(string[] args)
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/MakeDocWithSeparationColorSpace/MakeDocWithSeparationColorSpace.cs
+++ b/DotNET/Sample_Source/ContentCreation/MakeDocWithSeparationColorSpace/MakeDocWithSeparationColorSpace.cs
@@ -20,7 +20,7 @@ namespace MakeDocWithSeparationColorSpace
     {
         static void Main(string[] args)
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/NameTrees/NameTrees.cs
+++ b/DotNET/Sample_Source/ContentCreation/NameTrees/NameTrees.cs
@@ -26,7 +26,8 @@ namespace NameTrees
         static void Main()
         {
             Console.WriteLine("NameTree Sample:");
-            // This is the 30 day evaluation license key
+
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/NumberTrees/NumberTrees.cs
+++ b/DotNET/Sample_Source/ContentCreation/NumberTrees/NumberTrees.cs
@@ -26,7 +26,8 @@ namespace NumberTrees
         static void Main()
         {
             Console.WriteLine("NumberTree Sample:");
-            // This is the 30 day evaluation license key
+
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/RemoteGoToActions/RemoteGoToActions.cs
+++ b/DotNET/Sample_Source/ContentCreation/RemoteGoToActions/RemoteGoToActions.cs
@@ -25,7 +25,7 @@ namespace RemoteGoToActions
     {
         static void Main(string[] args)
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentCreation/WriteNChannelTiff/WriteNChannelTiff.cs
+++ b/DotNET/Sample_Source/ContentCreation/WriteNChannelTiff/WriteNChannelTiff.cs
@@ -24,7 +24,7 @@ namespace WriteNChannelTiff
         {
             Console.WriteLine("WriteNChannelTiff Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/Action/Action.cs
+++ b/DotNET/Sample_Source/ContentModification/Action/Action.cs
@@ -20,7 +20,7 @@ namespace Action
         {
             Console.WriteLine("Actions Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/AddCollection/AddCollection.cs
+++ b/DotNET/Sample_Source/ContentModification/AddCollection/AddCollection.cs
@@ -25,7 +25,7 @@ namespace AddCollection
         {
             Console.WriteLine("AddCollection Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.cs
+++ b/DotNET/Sample_Source/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.cs
@@ -29,7 +29,7 @@ namespace ChangeLayerConfiguration
         {
             Console.WriteLine("ChangeLayerConfiguration Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/ChangeLinkColors/ChangeLinkColors.cs
+++ b/DotNET/Sample_Source/ContentModification/ChangeLinkColors/ChangeLinkColors.cs
@@ -27,7 +27,7 @@ namespace ChangeLinkColors
         {
             Console.WriteLine("ChangeLinkColors Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/CreateLayer/CreateLayer.cs
+++ b/DotNET/Sample_Source/ContentModification/CreateLayer/CreateLayer.cs
@@ -26,7 +26,7 @@ namespace CreateLayer
         {
             Console.WriteLine("CreateLayer Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.cs
+++ b/DotNET/Sample_Source/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.cs
@@ -187,7 +187,8 @@ namespace ExtendedGraphicStates
         static void Main(string[] args)
         {
             Console.WriteLine("ExtendedGraphicStates Sample:");
-            // This is the 30 day evaluation license key
+
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/FlattenTransparency/FlattenTransparency.cs
+++ b/DotNET/Sample_Source/ContentModification/FlattenTransparency/FlattenTransparency.cs
@@ -31,7 +31,7 @@ namespace FlattenTransparency
         {
             Console.WriteLine("FlattenTransparency sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/LaunchActions/LaunchActions.cs
+++ b/DotNET/Sample_Source/ContentModification/LaunchActions/LaunchActions.cs
@@ -19,7 +19,7 @@ namespace LaunchActions
     {
         static void Main(string[] args)
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/MergePDF/MergePDF.cs
+++ b/DotNET/Sample_Source/ContentModification/MergePDF/MergePDF.cs
@@ -22,7 +22,7 @@ namespace MergePDF
         {
             Console.WriteLine("MergePDF Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/PDFObject/PDFObject.cs
+++ b/DotNET/Sample_Source/ContentModification/PDFObject/PDFObject.cs
@@ -26,7 +26,7 @@ namespace PDFObject
         {
             Console.WriteLine("PDFObject Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/PageLabels/PageLabels.cs
+++ b/DotNET/Sample_Source/ContentModification/PageLabels/PageLabels.cs
@@ -26,7 +26,7 @@ namespace PageLabels
         {
             Console.WriteLine("Page Labels Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.cs
+++ b/DotNET/Sample_Source/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.cs
@@ -23,7 +23,7 @@ namespace UnderlinesAndHighlights
         {
             Console.WriteLine("UnderlinesAndHighlights Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/ContentModification/Watermark/Watermark.cs
+++ b/DotNET/Sample_Source/ContentModification/Watermark/Watermark.cs
@@ -27,7 +27,8 @@ namespace Watermark
         static void Main(string[] args)
         {
             Console.WriteLine("Watermark Sample:");
-            // This is the 30 day evaluation license key
+
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Display/DisplayPDF/DisplayPDF.cs
+++ b/DotNET/Sample_Source/Display/DisplayPDF/DisplayPDF.cs
@@ -24,7 +24,7 @@ namespace DisplayPDF
         [STAThread]
         static void Main()
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (Library lib = new Library())

--- a/DotNET/Sample_Source/DocumentConversion/ColorConvertDocument/ColorConvertDocument.cs
+++ b/DotNET/Sample_Source/DocumentConversion/ColorConvertDocument/ColorConvertDocument.cs
@@ -30,7 +30,7 @@ namespace ColorConvertDocument
         {
             Console.WriteLine("ColorConvertDocument Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             List<string> paths = new List<string>();

--- a/DotNET/Sample_Source/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.cs
+++ b/DotNET/Sample_Source/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.cs
@@ -24,7 +24,7 @@ namespace CreateDocFromXPS
         {
             Console.WriteLine("CreateDocFromXPS sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using(Library lib = new Library())

--- a/DotNET/Sample_Source/DocumentConversion/Factur-XConverter/Factur-XConverter.cs
+++ b/DotNET/Sample_Source/DocumentConversion/Factur-XConverter/Factur-XConverter.cs
@@ -28,7 +28,7 @@ class FacturXConverter
         {
             Console.WriteLine("Factur-XConverter Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // Initialize the Library

--- a/DotNET/Sample_Source/DocumentConversion/PDFAConverter/PDFAConverter.cs
+++ b/DotNET/Sample_Source/DocumentConversion/PDFAConverter/PDFAConverter.cs
@@ -23,7 +23,7 @@ namespace PDFAConverter
         {
             Console.WriteLine("PDFAConverter Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/DocumentConversion/PDFXConverter/PDFXConverter.cs
+++ b/DotNET/Sample_Source/DocumentConversion/PDFXConverter/PDFXConverter.cs
@@ -26,7 +26,7 @@ namespace PDFXConverter
         {
             Console.WriteLine("PDFXConverter Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (Library lib = new Library())

--- a/DotNET/Sample_Source/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.cs
+++ b/DotNET/Sample_Source/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.cs
@@ -23,7 +23,7 @@ namespace ZUGFeRDConverter
             Console.WriteLine("ZUGFeRDConverter Sample:");
 
             //Initialize the Library
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
            // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/DocumentOptimization/PDFOptimize/PDFOptimize.cs
+++ b/DotNET/Sample_Source/DocumentOptimization/PDFOptimize/PDFOptimize.cs
@@ -29,7 +29,7 @@ namespace PDFOptimize
         {
             Console.WriteLine("PDF Optimizer:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Images/DocToImages/DocToImages.cs
+++ b/DotNET/Sample_Source/Images/DocToImages/DocToImages.cs
@@ -1074,7 +1074,7 @@ namespace DocToImages
                 Environment.Exit(1);
             }
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/DrawSeparations/DrawSeparations.cs
+++ b/DotNET/Sample_Source/Images/DrawSeparations/DrawSeparations.cs
@@ -26,7 +26,7 @@ namespace DrawSeparations
 
             Console.WriteLine("DrawSeparations Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/DrawToBitmap/DrawToBitmap.cs
+++ b/DotNET/Sample_Source/Images/DrawToBitmap/DrawToBitmap.cs
@@ -186,7 +186,7 @@ namespace DrawToBitmap
 
             try
             {
-                // This is the 30 day evaluation license key
+                // This is the evaluation license key
                 Library.LicenseKey = "3011-6479-7180-0953";
 
                 // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/EPSSeparations/EPSSeparations.cs
+++ b/DotNET/Sample_Source/Images/EPSSeparations/EPSSeparations.cs
@@ -25,7 +25,7 @@ namespace EPSSeparations
         {
             Console.WriteLine("EPS Separations Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/GetSeparatedImages/GetSeparatedImages.cs
+++ b/DotNET/Sample_Source/Images/GetSeparatedImages/GetSeparatedImages.cs
@@ -35,7 +35,7 @@ namespace GetSeparatedImages
 
             Console.WriteLine("Input file: " + sInput + ", will write to " + sOutput);
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.cs
+++ b/DotNET/Sample_Source/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.cs
@@ -90,7 +90,7 @@ namespace ImageEmbedICCProfile
 
             Console.WriteLine("Image Embed ICC Profile sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/ImageExport/ImageExport.cs
+++ b/DotNET/Sample_Source/Images/ImageExport/ImageExport.cs
@@ -147,7 +147,7 @@ namespace ImageExport
         {
             Console.WriteLine("Image Export sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/ImageExtraction/ImageExtraction.cs
+++ b/DotNET/Sample_Source/Images/ImageExtraction/ImageExtraction.cs
@@ -71,7 +71,7 @@ namespace ImageExtraction
 
             Console.WriteLine("ImageExtraction Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/ImageFromStream/ImageFromStream.cs
+++ b/DotNET/Sample_Source/Images/ImageFromStream/ImageFromStream.cs
@@ -31,7 +31,7 @@ namespace ImageFromStream
 
             Console.WriteLine("ImageFromStream Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/ImageImport/ImageImport.cs
+++ b/DotNET/Sample_Source/Images/ImageImport/ImageImport.cs
@@ -23,7 +23,8 @@ namespace ImageImport
         static void Main(string[] args)
         {
             Console.WriteLine("Import Images Sample:");
-            // This is the 30 day evaluation license key
+
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/ImageResampling/ImageResampling.cs
+++ b/DotNET/Sample_Source/Images/ImageResampling/ImageResampling.cs
@@ -76,7 +76,7 @@ namespace ImageResampling
         {
             Console.WriteLine("ImageResampling Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/ImageSoftMask/ImageSoftMask.cs
+++ b/DotNET/Sample_Source/Images/ImageSoftMask/ImageSoftMask.cs
@@ -25,7 +25,7 @@ namespace ImageSoftMask
         {
             Console.WriteLine("Image Soft Mask sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Images/RasterizePage/RasterizePage.cs
+++ b/DotNET/Sample_Source/Images/RasterizePage/RasterizePage.cs
@@ -39,7 +39,7 @@ namespace RasterizePage
 
             Console.WriteLine("RasterizePage Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/InformationExtraction/ListBookmarks/ListBookmarks.cs
+++ b/DotNET/Sample_Source/InformationExtraction/ListBookmarks/ListBookmarks.cs
@@ -50,7 +50,7 @@ namespace ListBookmarks
         {
             Console.WriteLine("ListBookmarks Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/InformationExtraction/ListInfo/ListInfo.cs
+++ b/DotNET/Sample_Source/InformationExtraction/ListInfo/ListInfo.cs
@@ -25,7 +25,7 @@ namespace ListInfo
         {
             Console.WriteLine("ListInfo Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/InformationExtraction/ListLayers/ListLayers.cs
+++ b/DotNET/Sample_Source/InformationExtraction/ListLayers/ListLayers.cs
@@ -23,7 +23,7 @@ namespace ListLayers
         {
             Console.WriteLine("ListLayers Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/InformationExtraction/ListPaths/ListPaths.cs
+++ b/DotNET/Sample_Source/InformationExtraction/ListPaths/ListPaths.cs
@@ -24,7 +24,7 @@ namespace ListPaths
         {
             Console.WriteLine("ListLayers Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/InformationExtraction/Metadata/Metadata.cs
+++ b/DotNET/Sample_Source/InformationExtraction/Metadata/Metadata.cs
@@ -24,7 +24,7 @@ namespace Metadata
     {
         static void Main(string[] args)
         {
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.cs
+++ b/DotNET/Sample_Source/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.cs
@@ -55,7 +55,7 @@ namespace AddTextToDocument
         {
             Console.WriteLine("AddTextToDocument Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.cs
+++ b/DotNET/Sample_Source/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.cs
@@ -24,7 +24,7 @@ namespace AddTextToImage
         {
             Console.WriteLine("AddTextToImage Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Other/MemoryFileSystem/MemoryFileSystem.cs
+++ b/DotNET/Sample_Source/Other/MemoryFileSystem/MemoryFileSystem.cs
@@ -24,7 +24,7 @@ namespace MemoryFileSystem
         {
             Console.WriteLine("MemoryFileSystem Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (Library lib = new Library())

--- a/DotNET/Sample_Source/Other/StreamIO/StreamIO.cs
+++ b/DotNET/Sample_Source/Other/StreamIO/StreamIO.cs
@@ -120,7 +120,8 @@ namespace StreamIO
         {
             StreamIOSample sample = new StreamIOSample();
             Console.WriteLine("StreamIO Sample:");
-            // This is the 30 day evaluation license key
+
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Printing/PrintPDF/PrintPDF.cs
+++ b/DotNET/Sample_Source/Printing/PrintPDF/PrintPDF.cs
@@ -86,7 +86,7 @@ namespace PrintPDF
 
             try
             {
-                // This is the 30 day evaluation license key
+                // This is the evaluation license key
                 Library.LicenseKey = "3011-6479-7180-0953";
 
                 // Printing may fail for reasons that have nothing to do with APDFL.

--- a/DotNET/Sample_Source/Printing/PrintPDFGUI/PrintPDFForm.cs
+++ b/DotNET/Sample_Source/Printing/PrintPDFGUI/PrintPDFForm.cs
@@ -29,7 +29,7 @@ namespace PrintPDFGUI
         {
             try
             {
-                // This is the 30 day evaluation license key
+                // This is the evaluation license key
                 Library.LicenseKey = "3011-6479-7180-0953";
 
                 using (Library lib = new Library())

--- a/DotNET/Sample_Source/Security/AddRegexRedaction/AddRegexRedaction.cs
+++ b/DotNET/Sample_Source/Security/AddRegexRedaction/AddRegexRedaction.cs
@@ -21,7 +21,7 @@ namespace AddRegexRedaction
         {
             Console.WriteLine("AddRegexRedaction Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Security/Redactions/Redactions.cs
+++ b/DotNET/Sample_Source/Security/Redactions/Redactions.cs
@@ -24,7 +24,7 @@ namespace Redactions
         {
             Console.WriteLine("Redactions Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Text/AddGlyphs/AddGlyphs.cs
+++ b/DotNET/Sample_Source/Text/AddGlyphs/AddGlyphs.cs
@@ -24,7 +24,7 @@ namespace AddGlyphs
         {
             Console.WriteLine("AddGlyphs Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Text/AddUnicodeText/AddUnicodeText.cs
+++ b/DotNET/Sample_Source/Text/AddUnicodeText/AddUnicodeText.cs
@@ -24,7 +24,7 @@ namespace AddUnicodeText
         {
             Console.WriteLine("AddUnicodeText Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Text/AddVerticalText/AddVerticalText.cs
+++ b/DotNET/Sample_Source/Text/AddVerticalText/AddVerticalText.cs
@@ -25,7 +25,7 @@ namespace AddVerticalText
         {
             Console.WriteLine("AddVerticalText Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.cs
+++ b/DotNET/Sample_Source/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.cs
@@ -32,7 +32,7 @@ namespace ExtractAcroFormFieldData
         {
             Console.WriteLine("ExtractAcroFormFieldData Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Text/ExtractCJKTextByPatternMatch/ExtractCJKTextByPatternMatch.cs
+++ b/DotNET/Sample_Source/Text/ExtractCJKTextByPatternMatch/ExtractCJKTextByPatternMatch.cs
@@ -20,7 +20,7 @@ namespace ExtractCJKTextByPatternMatch
         {
             Console.WriteLine("ExtractCJKTextByPatternMatch Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Text/ExtractTextByPatternMatch/ExtractTextByPatternMatch.cs
+++ b/DotNET/Sample_Source/Text/ExtractTextByPatternMatch/ExtractTextByPatternMatch.cs
@@ -20,7 +20,7 @@ namespace ExtractTextByPatternMatch
         {
             Console.WriteLine("ExtractTextByPatternMatch Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Text/ExtractTextByRegion/ExtractTextByRegion.cs
+++ b/DotNET/Sample_Source/Text/ExtractTextByRegion/ExtractTextByRegion.cs
@@ -32,7 +32,7 @@ namespace ExtractTextByRegion
         {
             Console.WriteLine("ExtractTextByRegion Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.cs
+++ b/DotNET/Sample_Source/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.cs
@@ -34,7 +34,7 @@ namespace ExtractTextFromAnnotations
         {
             Console.WriteLine("Annotations Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.cs
+++ b/DotNET/Sample_Source/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.cs
@@ -44,7 +44,7 @@ namespace ExtractTextFromMultiRegions
         {
             Console.WriteLine("ExtractTextFromMultiRegions Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.cs
+++ b/DotNET/Sample_Source/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.cs
@@ -28,7 +28,7 @@ namespace ExtractTextPreservingStyleAndPositionInfo
         {
             Console.WriteLine("ExtractTextPreservingStyleAndPositionInfo Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Text/ListWords/ListWords.cs
+++ b/DotNET/Sample_Source/Text/ListWords/ListWords.cs
@@ -24,7 +24,7 @@ namespace ListWords
         {
             Console.WriteLine("ListWords Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable

--- a/DotNET/Sample_Source/Text/RegexExtractText/RegexExtractText.cs
+++ b/DotNET/Sample_Source/Text/RegexExtractText/RegexExtractText.cs
@@ -94,7 +94,7 @@ namespace RegexExtractText
         {
             Console.WriteLine("RegexExtractText Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Text/RegexTextSearch/RegexTextSearch.cs
+++ b/DotNET/Sample_Source/Text/RegexTextSearch/RegexTextSearch.cs
@@ -21,7 +21,7 @@ namespace RegexTextSearch
         {
             Console.WriteLine("RegexTextSearch Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             using (new Library())

--- a/DotNET/Sample_Source/Text/TextExtract/TextExtract.cs
+++ b/DotNET/Sample_Source/Text/TextExtract/TextExtract.cs
@@ -25,7 +25,7 @@ namespace TextExtract
         {
             Console.WriteLine("TextExtract Sample:");
 
-            // This is the 30 day evaluation license key
+            // This is the evaluation license key
             Library.LicenseKey = "3011-6479-7180-0953";
 
             // ReSharper disable once UnusedVariable


### PR DESCRIPTION
These were set to false instead of their proper values so they became 0 which rasterizes the document when Flattened.

Remove 30-day license text because this may change.