### PR TITLE
Update and simplify .NET and .NET Framework markdown pages.

### DIFF
--- a/DotNET/Sample_Source/README.md
+++ b/DotNET/Sample_Source/README.md
@@ -2,7 +2,7 @@
 
 [Documentation](https://dev.datalogics.com/) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp;[Homepage](https://www.datalogics.com)
 
-![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NET?color=blue&label=APDFL%20.NET%20Free%20Trial&logo=NuGet&style=plastic)
+[![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NET?color=blue&label=APDFL%20.NET%20Free%20Trial&logo=NuGet&style=plastic)](https://www.nuget.org/packages/Adobe.PDF.Library.LM.NET)
 
 # .NET Samples
 ## ***Introduction***

--- a/DotNET/Sample_Source/README.md
+++ b/DotNET/Sample_Source/README.md
@@ -1,49 +1,45 @@
-![Datalogics Adobe PDF Library](https://www.datalogics.com/wp-content/uploads/2022/09/Datalogics-Logo-1-e1664565864201.png)
+![Datalogics Adobe PDF Library](https://raw.github.com/datalogics/dl-icons/develop/DLBanner_Nuget.png)
 
-[Datalogics](https://www.datalogics.com)&nbsp;|&nbsp; [Free Trial Download](https://www.datalogics.com/adobe-pdf-library/) &nbsp;|&nbsp; [Documentation](https://dev.datalogics.com/) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp;|&nbsp;[NuGet](https://www.nuget.org/profiles/Datalogics)
+[Documentation](https://dev.datalogics.com/) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp;[Homepage](https://www.datalogics.com)
 
-<br>
+![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NET?color=blue&label=APDFL%20.NET%20Free%20Trial&logo=NuGet&style=plastic)
 
-# .NET Sample Programs
+# .NET Samples
 ## ***Introduction***
-The Adobe PDF Library (APDFL) is an Application Programming Interface (API) designed to allow programmers to work with the Adobe PDF file format.  The APDFL Software Development Kit (SDK) provides a method for software developers and vendors to build their own third-party systems that allow them to create, change, process, review, and otherwise work with PDF files. The Library is the same one that Adobe Acrobat is based on.
+Built upon Adobe source code used for Acrobat, Datalogics Adobe PDF Library SDK provides stable, reliable code and the flexibility to develop with C# or VB (VB.NET) (interfaces are also available for C++ and Java). APDFL is the most complete SDK for PDF creation, manipulation and management. Best for enterprise/larger organizations of developers and independent software vendors (ISVs) who need to incorporate Adobe's PDF functionality into their own internal or external applications.
 
-Datalogics provides a .NET interface to the Adobe PDF Library. This Interface offers a set of modules for the Library that allow programmers working in C# or other languages supported by .NET to take advantage of Adobe PDF Library tools and resources. This interface encapsulates the original Adobe PDF Library; the interface allows you to work with the original library functions directly, and seamlessly, in .NET.
+## ***Preliminaries***
+Most of the code samples in APDFL are designed to demonstrate how an API works by completing a simple programming task.
 
-## ***The Sample Programs***
-The Adobe PDF Library supports all of the languages that work with .NET, including C# and Visual Basic. The Adobe PDF Library provides a set of sample C# program files, stored under /DotNet/Sample_Source.
+We assume a basic level of technical understanding of the PDF file format, invidual sample category directory markdown files go into more details.
 
-Most of the code samples in APDFL are designed to demonstrate how an API works by completing a simple programming task. You can open the sample .NET program files and review them in Microsoft Visual Studio 2019, Visual Studio Code, or a text editor on a Linux or macOS platform for reference, or you can copy parts of this code to use in your own programs.  You can also build and run sample programs from your Operating System command line.
+Many of these sample programs automatically generate an output file or set of files.  These output files, generally PDF or graphics files (JPG or BMP), are stored in the directory where the application has been run. If you run a sample program a second or third time, it will overwrite any output files that were created and stored earlier.  However, if you run a sample program, generate a PDF output file, and then open that PDF file and try to run that sample program again, you will see an error message.  The program will not be able to overwrite an existing output file if that file is currently open in another program.
 
-For example, you would access this directory, where the sample program files are stored, to build and run the sample:
+*(Note: that the Forms Extension product and samples are available by talking to Datalogics Sales.)*
 
-```C:\APDFL18\DotNet\Sample_Source\Text\```
+## ***Building and Running Samples***
+*Samples can be built and run easily in an IDE such as Visual Studio 2022 or VS Code.*
 
-We assume a basic level of technical understanding of the PDF file format, though we seek to review the features of each of these sample programs carefully.
+**Otherwise**, here are instructions for using **dotnet** instead:
 
-Many of these sample programs automatically generate an output file or set of files.  These output files, generally PDF or graphics files (JPG or BMP), are stored in the directory where the application has been run. If you run a sample program a second or third time, it will overwrite any output files that were created and stored earlier.  However, if you run a sample program, generate a PDF output file, and then open that PDF file and try to run that sample program again, you will see an error message.  The program will not be able to overwrite an existing output file if that file is currently open in Adobe Reader or Adobe Acrobat.
+Change to the directory of the program you want to work with. Here is an example:
 
-Note that the Forms Extension plug-in sample programs provided with the .NET Interface with the Adobe PDF Library are not available with .NET.
+```cd ./Images/RasterizePage```
 
-## ***Building and Running .NET Sample Programs***
-Start from your DotNet directory, and change to the Sample_Source directory for the program you want to work with. Here is an example:
-
-```cd Sample_Source/Images/RasterizePage```
-
-Build a sample project file using the Debug configuration. Use the dotnet program command, which is used with .NET to build projects and run applications:
+Build a sample project file using the **Debug** configuration using the **dotnet** program:
 
 ```dotnet build -c Debug ./RasterizePage.csproj /p:Platform=[x64|ARM64]```
 
-If you want to build a Release use this command syntax instead:
+If you want to build for **Release**, use this command syntax instead:
 
 ```dotnet build -c Release ./RasterizePage.csproj /p:Platform=[x64|ARM64]```
 
-Change to the **Binaries** directory:
+Change to the directory your sample built its executable to:
 
-```cd ../../../Binaries```
+```cd ./bin/Debug/net6.0/```
 
-Run the application by specifying the .dll file. Note the .dll file is the .NET executable for all platforms:
+Run the application by specifying the .dll file *(Note: the .dll file extension is the .NET executable for all platforms)*:
 
 ```dotnet ./RasterizePage.dll```
 
-**Note**: Adobe PDF Library dependencies are found in the DotNet/Binaries directory. Samples are setup to write their .NET .dll files to this directory along with any other dependencies, such as SkiaSharp.
+**Note**: Samples are setup to write their output files their program's executable directory along with any other dependencies, such as SkiaSharp for Graphics.

--- a/DotNETFramework/Sample_Source/README.md
+++ b/DotNETFramework/Sample_Source/README.md
@@ -1,16 +1,21 @@
-![Datalogics Adobe PDF Library](https://www.datalogics.com/wp-content/uploads/2022/09/Datalogics-Logo-1-e1664565864201.png)
+![Datalogics Adobe PDF Library](https://raw.github.com/datalogics/dl-icons/develop/DLBanner_Nuget.png)
 
-[Datalogics](https://www.datalogics.com)&nbsp;|&nbsp; [Free Trial Download](https://www.datalogics.com/adobe-pdf-library/) &nbsp;|&nbsp; [Documentation](https://dev.datalogics.com/) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp;|&nbsp;[NuGet](https://www.nuget.org/profiles/Datalogics)
+[Documentation](https://dev.datalogics.com/) &nbsp;| &nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp;[Homepage](https://www.datalogics.com)
 
-<br>
+![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NETFramework?color=blue&label=APDFL%20.NET%20Framework%20Free%20Trial&logo=NuGet&style=plastic)
 
-# .NET Framework Sample Programs
+# .NET Framework Samples
 ## ***Introduction***
-The Adobe PDF Library (APDFL) is an Application Programming Interface (API) designed to allow programmers to work with the Adobe PDF file format.  The APDFL Software Development Kit (SDK) provides a method for software developers and vendors to build their own third-party systems that allow them to create, change, process, review, and otherwise work with PDF files. The Library is the same one that Adobe Acrobat is based on.
+Built upon Adobe source code used for Acrobat, Datalogics Adobe PDF Library SDK provides stable, reliable code and the flexibility to develop with C# or VB (VB.NET) (interfaces are also available for C++ and Java). APDFL is the most complete SDK for PDF creation, manipulation and management. Best for enterprise/larger organizations of developers and independent software vendors (ISVs) who need to incorporate Adobe's PDF functionality into their own internal or external applications.
 
-Datalogics provides a .NET Framework interface to the Adobe PDF Library. This Interface offers a set of modules for the Library that allow programmers working in C# or other languages supported by .NET Framework to take advantage of Adobe PDF Library tools and resources. This interface encapsulates the original Adobe PDF Library; the interface allows you to work with the original library functions directly, and seamlessly, in .NET Framework.
+## ***Preliminaries***
+Most of the code samples in APDFL are designed to demonstrate how an API works by completing a simple programming task.
 
-## ***The Sample Programs***
-The Adobe PDF Library supports all of the languages that work with .NET Framework, including C# and Visual Basic. The Adobe PDF Library provides a set of sample C# program files, stored under /DotNetFramework/Sample_Source.
+We assume a basic level of technical understanding of the PDF file format, invidual sample category directory markdown files go into more details.
 
-Many of these sample programs automatically generate an output file or set of files.  These output files, generally PDF or graphics files (JPG or BMP), are stored in the directory where the application has been run. If you run a sample program a second or third time, it will overwrite any output files that were created and stored earlier.  However, if you run a sample program, generate a PDF output file, and then open that PDF file and try to run that sample program again, you will see an error message.  The program will not be able to overwrite an existing output file if that file is currently open in Adobe Reader or Adobe Acrobat.
+Many of these sample programs automatically generate an output file or set of files.  These output files, generally PDF or graphics files (JPG or BMP), are stored in the directory where the application has been run. If you run a sample program a second or third time, it will overwrite any output files that were created and stored earlier.  However, if you run a sample program, generate a PDF output file, and then open that PDF file and try to run that sample program again, you will see an error message.  The program will not be able to overwrite an existing output file if that file is currently open in another program.
+
+*(Note: that the Forms Extension product and samples are available by talking to Datalogics Sales.)*
+
+## ***Building and Running Samples***
+Samples can be built and run easily in an IDE such as Visual Studio 2017, 2019, or 2022.

--- a/DotNETFramework/Sample_Source/README.md
+++ b/DotNETFramework/Sample_Source/README.md
@@ -2,7 +2,7 @@
 
 [Documentation](https://dev.datalogics.com/) &nbsp;| &nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp;[Homepage](https://www.datalogics.com)
 
-![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NETFramework?color=blue&label=APDFL%20.NET%20Framework%20Free%20Trial&logo=NuGet&style=plastic)
+[![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NETFramework?color=blue&label=APDFL%20.NET%20Framework%20Free%20Trial&logo=NuGet&style=plastic)](https://www.nuget.org/packages/Adobe.PDF.Library.LM.NETFramework)
 
 # .NET Framework Samples
 ## ***Introduction***


### PR DESCRIPTION
Our sample instructions are simplified and more aesthetically pleasing now.

These instructions _should_ cater to Nuget users, users of the older-style installers wouldn't be cloning our sample repository in the first place since they would already have them installed.

They also wouldn't be needing to install the Library because they'd already have it, so the language that was applicable to installer users has been removed to be appropriate to our audience.
